### PR TITLE
do not fail if we cannot find sources for a binary-only framework

### DIFF
--- a/Source/CarthageKit/DebugSymbolsMapper.swift
+++ b/Source/CarthageKit/DebugSymbolsMapper.swift
@@ -25,7 +25,13 @@ final class DebugSymbolsMapper {
                 throw CarthageError.invalidDebugSymbols(dsymURL, description: "No debug symbols found at this location")
             }
 
-            let buildSourceURL: URL = try findBuildSourceURL(frameworkURL: frameworkURL, sourceURL: sourceURL)
+            let buildSourceURL: URL
+            do {
+                buildSourceURL = try findBuildSourceURL(frameworkURL: frameworkURL, sourceURL: sourceURL)
+            } catch let error as CarthageError {
+                print("Warning: " + error.description)
+                return .success(())
+            }
 
             let binaryUUIDs = try verifyUUIDs(frameworkURL: frameworkURL, dsymURL: dsymURL)
 


### PR DESCRIPTION
I'm sure this isn't the proper fix for this but hopefully it will start a discussion that leads to the proper fix. 

Currently Carthage fails on binary-only frameworks because it can't map debug symbols to source files. 

How to reproduce: 
Create this Cartfile: 
```
binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json"
```

Then run `carthage bootstrap --platform ios`

It will fail like this: 
```
Framework at path /var/folders/4r/5rcyrj_55nsf7c73sprfyn7r0000gr/T/carthage.ffqBs4/dynamic/Mapbox.framework was invalid: Could not find an appropriate debug symbols mapping for source path: /Users/jdoe/code/MyProject/Carthage/Checkouts/Mapbox-iOS-SDK
```

IMO missing source files should not be a fatal error. 