### PR TITLE
do not fail on binary-only frameworks if configuration=Debug

### DIFF
--- a/Source/CarthageKit/BinariesCache.swift
+++ b/Source/CarthageKit/BinariesCache.swift
@@ -123,7 +123,15 @@ final class BinaryProjectCache: AbstractBinariesCache {
 
     override func downloadBinary(for dependency: Dependency, pinnedVersion: PinnedVersion, configuration: String, swiftVersion: PinnedVersion, destinationURL: URL, eventObserver: Signal<ProjectEvent, NoError>.Observer?) -> SignalProducer<(), CarthageError> {
 
-        guard let binaryProject = self.binaryProjectDefinitions[dependency], let sourceURL = binaryProject.binaryURL(for: pinnedVersion, configuration: configuration, swiftVersion: swiftVersion) else {
+        let effectiveConfiguration: String
+        switch dependency {
+        case .binary: // don't fail if binary-only frameworks aren't available for Debug.
+            effectiveConfiguration = "Release"
+        default:
+            effectiveConfiguration = configuration
+        }
+
+        guard let binaryProject = self.binaryProjectDefinitions[dependency], let sourceURL = binaryProject.binaryURL(for: pinnedVersion, configuration: effectiveConfiguration, swiftVersion: swiftVersion) else {
 
             let error: CarthageError
             if let semanticVersion = pinnedVersion.semanticVersion {


### PR DESCRIPTION
Currently `carthage build` fails if there is a binary-only framework and `--configuration Debug` is used. 

This bug was introduced with the following commit: 
    b24eaa347e812fdc9ce7f328a67d9c9e6d2f21b4
    Date:   Fri Apr 26 12:54:23 2019 +0200
    Support for swift version and configuration (debug/release) for caches

To reproduce the problem, create this Cartfile: 
```
binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.0
```

then: 
```
$ carthage bootstrap --platform ios --configuration Debug
*** xcodebuild output can be found in /var/folders/4r/5rcyrj_55nsf7c73sprfyn7r0000gr/T/carthage-xcodebuild.WYsl2G.log
*** Downloading binary-only framework Mapbox-iOS-SDK at "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json"
No available version for binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" satisfies the requirement: == 4.11.0
```