### PR TITLE
Source hash calculation for dependencies to track local changes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "07cad52573bad19d95844035bf0b25acddf6b0f6",
-          "version": "0.15.0"
+          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
+          "version": "0.16.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
-          "version": "7.3.4"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
-          "version": "1.3.4"
+          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
+          "version": "2.1.0"
         }
       },
       {
@@ -60,17 +60,17 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {
           "branch": null,
-          "revision": "4f6a12ae6762e825b0e19a4f7076eafa43847e6e",
-          "version": "4.0.0"
+          "revision": "c37950dc5020544c58d4bf47c0d028893686b9e6",
+          "version": "5.0.1"
         }
       },
       {
         "package": "ReactiveTask",
         "repositoryURL": "https://github.com/nsoperations/ReactiveTask.git",
         "state": {
-          "branch": null,
-          "revision": "b0a322126f6c5147b2c59f4a414cea7fac0f45ac",
-          "version": "0.15.2"
+          "branch": "fix/handle-launch-exceptions",
+          "revision": "14ef462cf721633eaddd906b70cb7d2015d4ac6c",
+          "version": null
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/mdiep/Tentacle.git",
         "state": {
           "branch": null,
-          "revision": "5227e8ef290bc2fb0bab94caebe87f24525530ff",
-          "version": "0.13.0"
+          "revision": "578edd088b03bc749c49253b15ae2d5aaa9aa7df",
+          "version": "0.13.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
@@ -10,15 +10,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/antitypical/Result.git", from: "4.1.0"),
-        .package(url: "https://github.com/nsoperations/ReactiveTask.git", from: "0.15.2"),
-        .package(url: "https://github.com/Carthage/Commandant.git", from: "0.15.0"),
+        .package(url: "https://github.com/nsoperations/ReactiveTask.git", .branch("fix/handle-launch-exceptions")),
+        .package(url: "https://github.com/Carthage/Commandant.git", .exact("0.16.0")),
         .package(url: "https://github.com/jdhealy/PrettyColors.git", from: "5.0.2"),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "4.0.0"),
-        .package(url: "https://github.com/mdiep/Tentacle.git", from: "0.12.0"),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0"),
+        .package(url: "https://github.com/mdiep/Tentacle.git", from: "0.13.1"),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/nsoperations/BTree.git", from: "4.1.1"),
-        .package(url: "https://github.com/Quick/Quick.git", from: "1.3.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
     ],
     targets: [
         .target(
@@ -44,5 +44,5 @@ let package = Package(
             exclude: ["swift-is-crashy.c"]
         ),
     ],
-    swiftLanguageVersions: [4]
+    swiftLanguageVersions: [.v4_2]
 )

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ see [Installing Carthage](#installing-carthage)
 
 ## Change Log
 
+### 0.37.0+nsoperations
+
+- Added build option `--track-local-changes` to invalidate caches (in effect with `--cache-builds` and/or `--use-binaries`) when local changes were made to the source code of dependencies. This is handy for debugging the source code of dependencies.
+
 ### 0.36.3+nsoperations
 
 - Fixed bug where local binary caching would not work if CARTHAGE_CACHE_COMMAND environment variable was not present and the dependency was not a GitHub dependency.

--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -64,7 +64,7 @@ public final class Archive {
                         .map { url in framework.relativePath.deletingLastPathComponent.appendingPathComponent(url.lastPathComponent) }
                     let extraFilesProducer = SignalProducer(value: dSYM)
                         .concat(bcsymbolmapsProducer)
-                        .concat(versionFilePath.flatMap{ path -> SignalProducer<String, CarthageError>? in
+                        .concat(versionFilePath.flatMap { path -> SignalProducer<String, CarthageError>? in
                             return directoryURL.appendingPathComponent(path).isExistingFile ? SignalProducer<String, CarthageError>(value: path) : nil } ?? SignalProducer<String, CarthageError>.empty)
                     return SignalProducer(value: framework.relativePath)
                         .concat(extraFilesProducer)

--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -188,41 +188,4 @@ public final class Archive {
                     .then(SignalProducer<URL, CarthageError>(value: directoryURL))
         }
     }
-
-}
-
-extension String {
-    fileprivate func removingPrefix(_ prefix: String) -> String {
-        if self.hasPrefix(prefix) {
-            let startIndex = self.index(self.startIndex, offsetBy: prefix.count)
-            return String(self[startIndex..<self.endIndex])
-        } else {
-            return self
-        }
-    }
-
-    fileprivate func removingSuffix(_ suffix: String) -> String {
-        if self.hasSuffix(suffix) {
-            let endIndex = self.index(self.endIndex, offsetBy: -suffix.count)
-            return String(self[self.startIndex..<endIndex])
-        } else {
-            return self
-        }
-    }
-
-    fileprivate func appendingPathComponent(_ component: String) -> String {
-        return (self as NSString).appendingPathComponent(component)
-    }
-
-    fileprivate func appendingPathExtension(_ pathExtension: String) -> String {
-        return (self as NSString).appendingPathExtension(pathExtension)!
-    }
-
-    fileprivate var deletingLastPathComponent: String {
-        return (self as NSString).deletingLastPathComponent
-    }
-
-    fileprivate var lastPathComponent: String {
-        return (self as NSString).lastPathComponent
-    }
 }

--- a/Source/CarthageKit/BinariesCache.swift
+++ b/Source/CarthageKit/BinariesCache.swift
@@ -275,4 +275,3 @@ class LocalBinariesCache: ExternalTaskBinariesCache {
         super.init(taskCommand: "")
     }
 }
-

--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -16,6 +16,8 @@ public struct BuildOptions {
     public var useBinaries: Bool
     /// Custom executable or shell script to perform the caching implementation: recieves five arguments: dependencyName, dependencyVersion, buildConfiguration, swiftVersion, targetFilePath
     public var customCacheCommand: String?
+    /// Whether to track and compare local changes made to the dependency's source code (will cause a rebuild if so)
+    public var trackLocalChanges: Bool
 
     public init(
         configuration: String,
@@ -24,7 +26,8 @@ public struct BuildOptions {
         derivedDataPath: String? = nil,
         cacheBuilds: Bool = true,
         useBinaries: Bool = true,
-        customCacheCommand: String? = nil
+        customCacheCommand: String? = nil,
+        trackLocalChanges: Bool = false
         ) {
         self.configuration = configuration
         self.platforms = platforms
@@ -33,5 +36,6 @@ public struct BuildOptions {
         self.cacheBuilds = cacheBuilds
         self.useBinaries = useBinaries
         self.customCacheCommand = customCacheCommand
+        self.trackLocalChanges = trackLocalChanges
     }
 }

--- a/Source/CarthageKit/Cache.swift
+++ b/Source/CarthageKit/Cache.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/**
+ This class encapsulates basic dictionary operations with expiring values. This is intentionally implemented as a final class instead of a struct to allow a timer to target it for regular removal.
+ Also we don't want value semantics for a cache to avoid copying around the values.
+
+ Each stored value has an optional timeToLive which overrides the defaultTimeToLive which is supplied to the initializer.
+
+ This class is implemented in a thread-safe manner and is usable concurrently from multiple threads.
+ */
+public final class Cache<K: Hashable, V> {
+
+    // MARK: - Public properties
+
+    /**
+     Returns the non-expired entries of this storage as a dictionary.
+     */
+    public var dictionary: [K: V] {
+        return synchronized(self) {
+            return storage.reduce(into: [K: V](minimumCapacity: storage.count)) { (dict, entry) in
+                if !entry.value.isExpired {
+                    dict[entry.key] = entry.value.value
+                }
+            }
+        }
+    }
+
+    /**
+     Returns the size of the cache (including any expired values which have not yet been removed).
+     */
+    public var count: Int {
+        return synchronized(self) {
+            return storage.count
+        }
+    }
+
+    public let defaultTimeToLive: TimeInterval
+
+    // MARK: - Internal properties
+
+    internal var compactCount = 0
+
+    // MARK: - Private properties
+
+    private var storage = [K: ExpiringValue<V>]()
+    private var compactTimer: DispatchSourceTimer?
+
+    // MARK: - Object lifecycle
+
+    /**
+     Designated initializer which specifies an optional defaultTimeToLive and a compactInterval in case a timer should be scheduled to automatically compact the cache at regular times.
+     */
+    public init(defaultTimeToLive: TimeInterval = TimeInterval.greatestFiniteMagnitude, compactInterval: TimeInterval? = nil) {
+        self.defaultTimeToLive = defaultTimeToLive
+        if let interval = compactInterval {
+            //Triggers in a background queue, so won't disturb the main thread
+            let timer = DispatchSource.makeTimerSource()
+            timer.schedule(deadline: .now() + interval, repeating: interval)
+            timer.setEventHandler { [weak self] in
+                self?.compact()
+            }
+            timer.resume()
+            compactTimer = timer
+        }
+    }
+
+    deinit {
+        compactTimer?.cancel()
+    }
+
+    // MARK: - Public methods
+
+    /**
+     Retrieves the value for the specified key.
+
+     Returns nil if no value exists for this key or if the value has expired.
+     */
+    public subscript(_ key: K) -> V? {
+        get {
+            return synchronized(self) {
+                if let value = storage[key] {
+                    if value.isExpired {
+                        storage.removeValue(forKey: key)
+                    } else {
+                        return value.value
+                    }
+                }
+                return nil
+            }
+        }
+
+        set {
+            if let value = newValue {
+                updateValue(value, forKey: key)
+            } else {
+                removeValue(forKey: key)
+            }
+        }
+    }
+
+    /**
+     Retrieves or sets the value for the specified key with a specified expirationDate.
+
+     The expiration date has no effect on the getter, only the setter.
+
+     Returns nil if no value exists for this key or if the value has expired.
+     */
+    public subscript(_ key: K, expiringAt expirationDate: Date?) -> V? {
+        get {
+            return self[key]
+        }
+
+        set {
+            if let value = newValue {
+                updateValue(value, forKey: key, expirationDate: expirationDate)
+            } else {
+                removeValue(forKey: key)
+            }
+        }
+    }
+
+    /**
+     Retrieves or sets the value for the specified key with a specified timeToLive (time interval added to the current date).
+
+     The timeToLive has no effect on the getter, only the setter.
+
+     Returns nil if no value exists for this key or if the value has expired.
+     */
+    public subscript(_ key: K, timeToLive timeToLive: TimeInterval) -> V? {
+        get {
+            return self[key]
+        }
+
+        set {
+            if let value = newValue {
+                updateValue(value, forKey: key, expirationDate: Date(timeIntervalSinceNow: timeToLive))
+            } else {
+                removeValue(forKey: key)
+            }
+        }
+    }
+
+    /**
+     Puts the value for the specified key and returns the old value if present.
+
+     If expirationDate is specified, the stored value will automatically expire after the specified date. If no expiration date is specified the default time to live is used.
+     */
+    @discardableResult
+    public func updateValue(_ value: V, forKey key: K, expirationDate: Date? = nil) -> V? {
+        return synchronized(self) {
+            return storage.updateValue(ExpiringValue(value, expirationDate: expirationDate ?? Date(timeIntervalSinceNow: defaultTimeToLive)), forKey: key).map { $0.value }
+        }
+    }
+
+    /**
+     Removes the value for the specified key.
+     */
+    @discardableResult
+    public func removeValue(forKey key: K) -> V? {
+        return synchronized(self) {
+            if let value = storage.removeValue(forKey: key) {
+                return value.value
+            }
+            return nil
+        }
+    }
+
+    /**
+     Removes all stored values.
+     */
+    public func removeAll() {
+        synchronized(self) {
+            storage.removeAll()
+        }
+    }
+
+    /**
+     Ensures expired values are removed from the storage.
+     */
+    public func compact() {
+        synchronized(self) {
+            storage = storage.filter { !$1.isExpired }
+            compactCount += 1
+        }
+    }
+
+    // MARK: - ExpiringValue
+
+    private struct ExpiringValue<V> {
+        let value: V
+        let expirationDate: Date?
+
+        var isExpired: Bool {
+            return isExpired(forDate: Date())
+        }
+
+        func isExpired(forDate date: Date) -> Bool {
+            return expirationDate.map { $0 < date } ?? false
+        }
+
+        init(_ value: V, expirationDate: Date?) {
+            self.value = value
+            self.expirationDate = expirationDate
+        }
+    }
+}
+
+/**
+ Swift equivalence of @synchronized in ObjectiveC until a native language alternative comes around.
+ */
+@discardableResult
+fileprivate func synchronized<T>(_ object: AnyObject, closure: () throws -> T) rethrows -> T {
+    objc_sync_enter(object)
+    defer {
+        objc_sync_exit(object)
+    }
+    return try closure()
+}

--- a/Source/CarthageKit/Cache.swift
+++ b/Source/CarthageKit/Cache.swift
@@ -17,7 +17,7 @@ public final class Cache<K: Hashable, V> {
      */
     public var dictionary: [K: V] {
         return synchronized(self) {
-            return storage.reduce(into: [K: V](minimumCapacity: storage.count)) { (dict, entry) in
+            return storage.reduce(into: [K: V](minimumCapacity: storage.count)) { dict, entry in
                 if !entry.value.isExpired {
                     dict[entry.key] = entry.value.value
                 }
@@ -209,7 +209,7 @@ public final class Cache<K: Hashable, V> {
  Swift equivalence of @synchronized in ObjectiveC until a native language alternative comes around.
  */
 @discardableResult
-fileprivate func synchronized<T>(_ object: AnyObject, closure: () throws -> T) rethrows -> T {
+private func synchronized<T>(_ object: AnyObject, closure: () throws -> T) rethrows -> T {
     objc_sync_enter(object)
     defer {
         objc_sync_exit(object)

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,5 +1,5 @@
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
     public let value: SemanticVersion
-    public static let current = CarthageKitVersion(value: SemanticVersion(0, 36, 3, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["nsoperations"]))
+    public static let current = CarthageKitVersion(value: SemanticVersion(0, 37, 0, prereleaseIdentifiers: ["beta"], buildMetadataIdentifiers: ["nsoperations"]))
 }

--- a/Source/CarthageKit/Dependencies.swift
+++ b/Source/CarthageKit/Dependencies.swift
@@ -25,4 +25,68 @@ final class Dependencies {
     static func repositoryFileURL(for dependency: Dependency, baseURL: URL) -> URL {
         return baseURL.appendingPathComponent(dependency.name, isDirectory: true)
     }
+
+    static func fetchDependencyNameForRepository(at repositoryFileURL: URL? = nil) -> SignalProducer<String, CarthageError> {
+        /*
+         List all remotes known for this repository
+         and keep only the "fetch" urls by which the current repository
+         would be known for the purpose of fetching anyways.
+
+         Example of well-formed output:
+
+         $ git remote -v
+         origin   https://github.com/blender/Carthage.git (fetch)
+         origin   https://github.com/blender/Carthage.git (push)
+         upstream https://github.com/Carthage/Carthage.git (fetch)
+         upstream https://github.com/Carthage/Carthage.git (push)
+
+         Example of ill-formed output where upstream does not have a url:
+
+         $ git remote -v
+         origin   https://github.com/blender/Carthage.git (fetch)
+         origin   https://github.com/blender/Carthage.git (push)
+         upstream
+         */
+        let allRemoteURLs = Git.launchGitTask(["remote", "-v"], repositoryFileURL: repositoryFileURL)
+            .flatMap(.concat) { $0.linesProducer }
+            .map { $0.components(separatedBy: .whitespacesAndNewlines) }
+            .filter { $0.count >= 3 && $0.last == "(fetch)" } // Discard ill-formed output as of example
+            .map { ($0[0], $0[1]) }
+            .collect()
+
+        let currentProjectName = allRemoteURLs
+            // Assess the popularity of each remote url
+            .map { $0.reduce([String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]()) { remoteURLPopularityMap, remoteNameAndURL in
+                let (remoteName, remoteUrl) = remoteNameAndURL
+                var remoteURLPopularityMap = remoteURLPopularityMap
+                if let existingEntry = remoteURLPopularityMap[remoteName] {
+                    remoteURLPopularityMap[remoteName] = (existingEntry.popularity + 1, existingEntry.remoteNameAndURL)
+                } else {
+                    remoteURLPopularityMap[remoteName] = (0, (remoteName, remoteUrl))
+                }
+                return remoteURLPopularityMap
+                }
+            }
+            // Pick "origin" if it exists,
+            // otherwise sort remotes by popularity
+            // or alphabetically in case of a draw
+            .map { (remotePopularityMap: [String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]) -> String in
+                guard let origin = remotePopularityMap["origin"] else {
+                    let urlOfMostPopularRemote = remotePopularityMap.sorted { lhs, rhs in
+                        if lhs.value.popularity == rhs.value.popularity {
+                            return lhs.key < rhs.key
+                        }
+                        return lhs.value.popularity > rhs.value.popularity
+                        }
+                        .first?.value.remoteNameAndURL.url
+
+                    // If the reposiroty is not pushed to any remote
+                    // the list of remotes is empty, so call the current project... "_Current"
+                    return urlOfMostPopularRemote.flatMap { Dependency.git(GitURL($0)).name } ?? "_Current"
+                }
+
+                return Dependency.git(GitURL(origin.remoteNameAndURL.url)).name
+        }
+        return currentProjectName
+    }
 }

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -48,7 +48,11 @@ public enum Dependency: Hashable {
     /// The path at which this project will be checked out, relative to the
     /// working directory of the main project.
     public var relativePath: String {
-        return (carthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
+        return Dependency.relativePath(dependencyName: self.name)
+    }
+    
+    public static func relativePath(dependencyName: String) -> String {
+        return carthageProjectCheckoutsPath.appendingPathComponent(dependencyName)
     }
 }
 

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -50,7 +50,7 @@ public enum Dependency: Hashable {
     public var relativePath: String {
         return Dependency.relativePath(dependencyName: self.name)
     }
-    
+
     public static func relativePath(dependencyName: String) -> String {
         return carthageProjectCheckoutsPath.appendingPathComponent(dependencyName)
     }

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -47,6 +47,22 @@ extension String {
     internal func containsAny(_ characterSet: CharacterSet) -> Bool {
         return self.rangeOfCharacter(from: characterSet) != nil
     }
+    
+    internal func appendingPathComponent(_ component: String) -> String {
+        return (self as NSString).appendingPathComponent(component)
+    }
+    
+    internal func appendingPathExtension(_ pathExtension: String) -> String {
+        return (self as NSString).appendingPathExtension(pathExtension)!
+    }
+    
+    internal var deletingLastPathComponent: String {
+        return (self as NSString).deletingLastPathComponent
+    }
+    
+    internal var lastPathComponent: String {
+        return (self as NSString).lastPathComponent
+    }
 }
 
 extension Signal {

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -47,19 +47,19 @@ extension String {
     internal func containsAny(_ characterSet: CharacterSet) -> Bool {
         return self.rangeOfCharacter(from: characterSet) != nil
     }
-    
+
     internal func appendingPathComponent(_ component: String) -> String {
         return (self as NSString).appendingPathComponent(component)
     }
-    
+
     internal func appendingPathExtension(_ pathExtension: String) -> String {
         return (self as NSString).appendingPathExtension(pathExtension)!
     }
-    
+
     internal var deletingLastPathComponent: String {
         return (self as NSString).deletingLastPathComponent
     }
-    
+
     internal var lastPathComponent: String {
         return (self as NSString).lastPathComponent
     }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -613,7 +613,7 @@ public final class Project { // swiftlint:disable:this type_body_length
                 return SignalProducer.combineLatest(
                     SignalProducer(value: (dependency, version)),
                     self.dependencyRetriever.dependencySet(for: dependency, version: version),
-                    VersionFile.versionFileMatches(dependency, version: version, platforms: options.platforms, configuration: options.configuration, rootDirectoryURL: self.directoryURL, toolchain: options.toolchain)
+                    VersionFile.versionFileMatches(dependency, version: version, platforms: options.platforms, configuration: options.configuration, rootDirectoryURL: self.directoryURL, toolchain: options.toolchain, checkSourceHash: options.trackLocalChanges)
                 )
             }
             .reduce([]) { includedDependencies, nextGroup -> [(Dependency, PinnedVersion)] in
@@ -671,7 +671,8 @@ public final class Project { // swiftlint:disable:this type_body_length
                             platforms: options.platforms,
                             configuration: options.configuration,
                             rootDirectoryURL: self.directoryURL,
-                            toolchain: options.toolchain
+                            toolchain: options.toolchain,
+                            checkSourceHash: options.trackLocalChanges
                             )
                             .map { matches in return (dependency, version, matches) }
                     }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -573,7 +573,7 @@ public final class Project { // swiftlint:disable:this type_body_length
                 }
             }
             .flatMap(.latest) { (graph: DependencyGraph) -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
-                var filteredDependencies: Set<Dependency>? = nil
+                var filteredDependencies: Set<Dependency>?
                 if let dependenciesToInclude = dependenciesToInclude {
                     filteredDependencies = Set(graph
                         .map { dependency, _ in dependency }

--- a/Source/CarthageKit/ProjectDependencyRetriever.swift
+++ b/Source/CarthageKit/ProjectDependencyRetriever.swift
@@ -398,7 +398,7 @@ public final class ProjectDependencyRetriever: DependencyRetrieverProtocol {
         return FileManager.default.reactive.createTemporaryDirectory()
             .flatMap(.merge) { tempDirectoryURL -> SignalProducer<URL, CarthageError> in
                 tempDir = tempDirectoryURL
-                return Archive.archiveFrameworks(frameworkNames: frameworkNames, directoryURL: self.directoryURL, customOutputPath: tempDirectoryURL.appendingPathComponent(dependency.name + ".framework.zip").path)
+                return Archive.archiveFrameworks(frameworkNames: frameworkNames, dependencyName: dependency.name, directoryURL: self.directoryURL, customOutputPath: tempDirectoryURL.appendingPathComponent(dependency.name + ".framework.zip").path)
             }
             .flatMap(.merge) { archiveURL -> SignalProducer<URL, CarthageError> in
                 return SwiftToolchain.swiftVersion(usingToolchain: toolchain)

--- a/Source/CarthageKit/SHA256Digest.swift
+++ b/Source/CarthageKit/SHA256Digest.swift
@@ -2,19 +2,19 @@ import Foundation
 import CommonCrypto
 
 final class SHA256Digest {
-    
+
     enum InputStreamError: Error {
         case createFailed(URL)
         case readFailed
     }
-    
+
     private lazy var context: CC_SHA256_CTX = {
         var shaContext = CC_SHA256_CTX()
         CC_SHA256_Init(&shaContext)
         return shaContext
     }()
-    private var result: Data? = nil
-    
+    private var result: Data?
+
     init() {
     }
 
@@ -24,7 +24,7 @@ final class SHA256Digest {
         }
         return try update(inputStream: inputStream)
     }
-    
+
     func update(inputStream: InputStream) throws {
         guard result == nil else {
             return
@@ -33,7 +33,7 @@ final class SHA256Digest {
         defer {
             inputStream.close()
         }
-        let bufferSize = 4096
+        let bufferSize = 4_096
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer {
             buffer.deallocate()
@@ -50,7 +50,7 @@ final class SHA256Digest {
             self.update(bytes: buffer, length: bytesRead)
         }
     }
-    
+
     func update(data: Data) {
         guard result == nil else {
             return
@@ -59,14 +59,14 @@ final class SHA256Digest {
             self.update(bytes: $0, length: data.count)
         }
     }
-    
+
     func update(bytes: UnsafeRawPointer, length: Int) {
         guard result == nil else {
             return
         }
         _ = CC_SHA256_Update(&self.context, bytes, CC_LONG(length))
     }
-    
+
     func finalize() -> Data {
         if let calculatedResult = result {
             return calculatedResult
@@ -77,7 +77,7 @@ final class SHA256Digest {
         result = theResult
         return theResult
     }
-    
+
     static func sum(_ data: Data) -> Data {
         let digest = SHA256Digest()
         digest.update(data: data)
@@ -103,11 +103,11 @@ extension Data {
         "c",
         "d",
         "e",
-        "f"
+        "f",
     ]
 
     var hexString: String {
-        return self.reduce(into: String(), { (result, byte) in
+        return self.reduce(into: String(), { result, byte in
             let c1: Character = Data.hexCharacterLookupTable[Int(byte >> 4)]
             let c2: Character = Data.hexCharacterLookupTable[Int(byte & 0x0F)]
             result.append(c1)

--- a/Source/CarthageKit/SHA256Digest.swift
+++ b/Source/CarthageKit/SHA256Digest.swift
@@ -4,6 +4,7 @@ import CommonCrypto
 final class SHA256Digest {
     
     enum InputStreamError: Error {
+        case createFailed(URL)
         case readFailed
     }
     
@@ -16,14 +17,28 @@ final class SHA256Digest {
     
     init() {
     }
+
+    func update(url: URL) throws {
+        guard let inputStream = InputStream(url: url) else {
+            throw InputStreamError.createFailed(url)
+        }
+        return try update(inputStream: inputStream)
+    }
     
     func update(inputStream: InputStream) throws {
         guard result == nil else {
             return
         }
+        inputStream.open()
+        defer {
+            inputStream.close()
+        }
         let bufferSize = 4096
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-        while true {
+        defer {
+            buffer.deallocate()
+        }
+        while inputStream.hasBytesAvailable {
             let bytesRead = inputStream.read(buffer, maxLength: bufferSize)
             if bytesRead < 0 {
                 //Stream error occured
@@ -34,7 +49,6 @@ final class SHA256Digest {
             }
             self.update(bytes: buffer, length: bytesRead)
         }
-        buffer.deallocate()
     }
     
     func update(data: Data) {
@@ -68,5 +82,36 @@ final class SHA256Digest {
         let digest = SHA256Digest()
         digest.update(data: data)
         return digest.finalize()
+    }
+}
+
+extension Data {
+
+    private static let hexCharacterLookupTable: [Character] = [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+    ]
+
+    var hexString: String {
+        return self.reduce(into: String(), { (result, byte) in
+            let c1: Character = Data.hexCharacterLookupTable[Int(byte >> 4)]
+            let c2: Character = Data.hexCharacterLookupTable[Int(byte & 0x0F)]
+            result.append(c1)
+            result.append(c2)
+        })
     }
 }

--- a/Source/CarthageKit/SHA256Digest.swift
+++ b/Source/CarthageKit/SHA256Digest.swift
@@ -1,0 +1,72 @@
+import Foundation
+import CommonCrypto
+
+final class SHA256Digest {
+    
+    enum InputStreamError: Error {
+        case readFailed
+    }
+    
+    private lazy var context: CC_SHA256_CTX = {
+        var shaContext = CC_SHA256_CTX()
+        CC_SHA256_Init(&shaContext)
+        return shaContext
+    }()
+    private var result: Data? = nil
+    
+    init() {
+    }
+    
+    func update(inputStream: InputStream) throws {
+        guard result == nil else {
+            return
+        }
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        while true {
+            let bytesRead = inputStream.read(buffer, maxLength: bufferSize)
+            if bytesRead < 0 {
+                //Stream error occured
+                throw (inputStream.streamError ?? InputStreamError.readFailed)
+            } else if bytesRead == 0 {
+                //EOF
+                break
+            }
+            self.update(bytes: buffer, length: bytesRead)
+        }
+        buffer.deallocate()
+    }
+    
+    func update(data: Data) {
+        guard result == nil else {
+            return
+        }
+        data.withUnsafeBytes {
+            self.update(bytes: $0, length: data.count)
+        }
+    }
+    
+    func update(bytes: UnsafeRawPointer, length: Int) {
+        guard result == nil else {
+            return
+        }
+        _ = CC_SHA256_Update(&self.context, bytes, CC_LONG(length))
+    }
+    
+    func finalize() -> Data {
+        if let calculatedResult = result {
+            return calculatedResult
+        }
+        var resultBuffer = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        CC_SHA256_Final(&resultBuffer, &self.context)
+        let theResult = Data(bytes: resultBuffer)
+        result = theResult
+        return theResult
+    }
+    
+    static func sum(_ data: Data) -> Data {
+        let digest = SHA256Digest()
+        digest.update(data: data)
+        return digest.finalize()
+    }
+}

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -253,11 +253,11 @@ struct VersionFile: Codable {
         hashes: [String?],
         swiftVersionMatches: [Bool]
         ) -> SignalProducer<Bool, CarthageError> {
-        
+
         if let definedSourceHash = self.sourceHash, let suppliedSourceHash = sourceHash, definedSourceHash != suppliedSourceHash {
             return SignalProducer(value: false)
         }
-        
+
         guard let cachedFrameworks = self[platform], commitish == self.commitish, configuration == self.configuration else {
             return SignalProducer(value: false)
         }
@@ -451,7 +451,7 @@ extension VersionFile {
             .appendingPathComponent(".\(dependencyName).\(VersionFile.pathExtension)")
         return versionFileURL
     }
-    
+
     /// Determines whether a dependency can be skipped because it is
     /// already cached.
     ///
@@ -479,7 +479,7 @@ extension VersionFile {
         return SwiftToolchain.swiftVersion(usingToolchain: toolchain)
             .mapError { error in CarthageError.internalError(description: error.description) }
             .combineLatest(with: checkSourceHash ? self.sourceHash(dependencyName: dependency.name, rootDirectoryURL: rootDirectoryURL) : SignalProducer<String?, CarthageError>(value: nil))
-            .flatMap(.concat) { (localSwiftVersion, sourceHash) in
+            .flatMap(.concat) { localSwiftVersion, sourceHash in
                 return versionFile.satisfies(platforms: platforms,
                                              commitish: commitish,
                                              sourceHash: sourceHash,
@@ -546,7 +546,7 @@ extension VersionFile {
             let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
             var enumerationError: (error: Error, url: URL)?
 
-            let errorHandler: (URL, Error) -> Bool = { (url, error) -> Bool in
+            let errorHandler: (URL, Error) -> Bool = { url, error -> Bool in
                 enumerationError = (error, url)
                 return false
             }

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -51,8 +51,7 @@ public struct ArchiveCommand: CommandProtocol {
         let formatting = options.colorOptions.formatting
         let frameworkNames = options.frameworkNames
         let directoryURL = URL(fileURLWithPath: options.directoryPath)
-
-        return Archive.archiveFrameworks(frameworkNames: frameworkNames, directoryURL: directoryURL, customOutputPath: options.outputPath, frameworkFoundHandler: { path in
+        return Archive.archiveFrameworks(frameworkNames: frameworkNames, dependencyName: nil, directoryURL: directoryURL, customOutputPath: options.outputPath, frameworkFoundHandler: { path in
             carthage.println(formatting.bullets + "Found " + formatting.path(path))
         }).on(value: { outputURL in
             carthage.println(formatting.bullets + "Created " + formatting.path(outputURL.path))

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -22,6 +22,7 @@ extension BuildOptions: OptionsProtocol {
         let option4 = Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
         let option5 = Option(key: "use-binaries", defaultValue: true, usage: "don't use remotely or locally cached binaries when possible")
         let option6 = Option<String?>(key: "cache-command", defaultValue: Environment.getVariable("CARTHAGE_CACHE_COMMAND").value, usage: "custom command to execute to download cached (binary) dependencies from a custom cache store. Five environment variables will be set which can be used by the command if needed: [CARTHAGE_CACHE_DEPENDENCY_NAME, CARTHAGE_CACHE_DEPENDENCY_VERSION, CARTHAGE_CACHE_BUILD_CONFIGURATION, CARTHAGE_CACHE_SWIFT_VERSION, CARTHAGE_CACHE_TARGET_FILE_PATH]. The executable should move the cached file to the targetFilePath when successful. The CARTHAGE_CACHE_COMMAND environment variable is read for a default for this value. If not specified, caching will revert to caching based on the GitHub API which only works for GitHub dependencies.")
+        let option7 = Option(key: "track-local-changes", defaultValue: false, usage: "track local changes made to dependencies to determine if a rebuild is necessary in combination with --use-binaries/--cache-builds. By default only the git commit hash is used so a rebuild is triggered only if the dependency commit hash did change.")
 
         return curry(self.init)
             <*> mode <| option1
@@ -31,6 +32,7 @@ extension BuildOptions: OptionsProtocol {
             <*> mode <| option4
             <*> mode <| option5
             <*> mode <| option6
+            <*> mode <| option7
     }
 }
 

--- a/Tests/CarthageKitTests/DigestTests.swift
+++ b/Tests/CarthageKitTests/DigestTests.swift
@@ -1,0 +1,100 @@
+//
+//  DigestTests.swift
+//  CarthageKitTests
+//
+//  Created by Werner Altewischer on 05/07/2019.
+//
+
+import XCTest
+import ReactiveTask
+@testable import CarthageKit
+
+class DigestTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testSHADigestFromFile() throws {
+        let data = Data.makeRandom(length: 100 * 1024)
+        let fileURL = try makeTempFile(data: data)
+
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
+        do {
+            let digest = SHA256Digest()
+
+            try digest.update(url: fileURL)
+            let result = digest.finalize().hexString
+
+            let expected = try referenceSHA256Sum(data: data)
+
+            XCTAssertEqual(expected, result)
+        } catch {
+            XCTFail("Unexpected error thrown: \(error)")
+        }
+    }
+
+    func testSHADigestFromData() throws {
+        let data = Data.makeRandom(length: 4096)
+
+        let digest = SHA256Digest()
+        digest.update(data: data)
+        let result = digest.finalize().hexString
+
+        let expected = try referenceSHA256Sum(data: data)
+
+        XCTAssertEqual(expected, result)
+
+        //Should be ignored, already finalized
+        digest.update(data: data)
+
+        //Should yield the same result
+        let result1 = digest.finalize().hexString
+
+        XCTAssertEqual(expected, result1)
+    }
+
+    private func makeTempFile(data: Data) throws -> URL {
+        let tempDir = NSTemporaryDirectory()
+        let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
+        let url = URL(fileURLWithPath: tempFile)
+        try data.write(to: url)
+        return url
+    }
+
+    private func referenceSHA256Sum(data: Data) throws -> String {
+        let tempURL = try makeTempFile(data: data)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+
+        let task = Task("/usr/bin/shasum", arguments: ["-a", "256", tempURL.path])
+
+        let result = task.getStdOutString()
+
+        return try String(result.get().prefix(64))
+    }
+
+}
+
+extension Data {
+    // Create random data with the specified length in bytes
+    static func makeRandom(length: Int) -> Data {
+        var result = Data(capacity: length)
+        for _ in 0..<length {
+            guard let byte = UInt8(exactly: arc4random_uniform(UInt32(UInt8.max) + 1)) else {
+                preconditionFailure("Expected the random byte to hava value in the range [0, UInt8.max]")
+            }
+            result.append(byte)
+        }
+        return result
+    }
+}

--- a/Tests/CarthageKitTests/VersionFileTests.swift
+++ b/Tests/CarthageKitTests/VersionFileTests.swift
@@ -52,6 +52,7 @@ class VersionFileTests: XCTestCase {
 										hash: "TestHASH",
 										swiftToolchainVersion: "4.2 (swiftlang-1000.11.37.1 clang-1000.11.45.1)")
 		let versionFile = VersionFile(commitish: "v1.0",
+                                      sourceHash: nil,
                                       configuration: "Debug",
 									  macOS: nil,
 									  iOS: [framework],
@@ -138,7 +139,7 @@ class VersionFileTests: XCTestCase {
 	
     func validate(file: VersionFile, matches: Bool, platform: Platform, commitish: String, configuration: String = "Debug", hashes: [String?],
 				  swiftVersionMatches: [Bool], fileName: FileString = #file, line: UInt = #line) {
-        _ = file.satisfies(platform: platform, commitish: commitish, configuration: configuration, hashes: hashes, swiftVersionMatches: swiftVersionMatches)
+        _ = file.satisfies(platform: platform, commitish: commitish, sourceHash: nil, configuration: configuration, hashes: hashes, swiftVersionMatches: swiftVersionMatches)
 			.on(value: { didMatch in
 				expect(didMatch, file: fileName, line: line) == matches
 			})


### PR DESCRIPTION
Added build option `--track-local-changes` which, if present, will automatically invalidate the cache when local changes to the checked out source code of a particular dependency has been made (inside Carthage/Checkouts/SomeDependency).