### PR TITLE
Ensured carthage validate also checks the Cartfile/Cartfile.private

### DIFF
--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -9,7 +9,38 @@ public struct CompatibilityInfo: Equatable {
             lhs.requirements == rhs.requirements
     }
 
-    public typealias Requirements = [Dependency: [Dependency: VersionSpecifier]]
+    public typealias Requirement = (Dependency, VersionSpecifier)
+
+    public struct Requirements {
+
+        fileprivate var lookupTable: [Dependency?: [Dependency: VersionSpecifier]]
+
+        public init() {
+            self.init([Dependency?: [Dependency: VersionSpecifier]]())
+        }
+
+        public init(_ lookupTable: [Dependency?: [Dependency: VersionSpecifier]]) {
+            self.lookupTable = lookupTable
+        }
+
+        var count: Int {
+            return self.lookupTable.count
+        }
+
+        mutating func setRequirement(_ requirement: Requirement, from definingDependency: Dependency?) {
+            self.lookupTable[definingDependency, default: [Dependency: VersionSpecifier]()][requirement.0] = requirement.1
+        }
+
+        func hasRequirement(for dependency: Dependency, from definingDependency: Dependency?) -> Bool {
+            return self.requirements(from: definingDependency)?[dependency] != nil
+        }
+
+        func requirements(from definingDependency: Dependency?) -> [Dependency: VersionSpecifier]? {
+            return self.lookupTable[definingDependency]
+        }
+    }
+
+    //public typealias Requirements = [Dependency: [Dependency: VersionSpecifier]]
 
     /// The dependency
     public let dependency: Dependency
@@ -18,11 +49,11 @@ public struct CompatibilityInfo: Equatable {
     public let pinnedVersion: PinnedVersion
 
     /// Requirements with which the pinned version of this dependency may or may not be compatible
-    private let requirements: [Dependency: VersionSpecifier]
+    private let requirements: [Dependency?: VersionSpecifier]
 
     private let projectDependencyRetriever: DependencyRetrieverProtocol
 
-    public init(dependency: Dependency, pinnedVersion: PinnedVersion, requirements: [Dependency: VersionSpecifier], projectDependencyRetriever: DependencyRetrieverProtocol) {
+    public init(dependency: Dependency, pinnedVersion: PinnedVersion, requirements: [Dependency?: VersionSpecifier], projectDependencyRetriever: DependencyRetrieverProtocol) {
         self.dependency = dependency
         self.pinnedVersion = pinnedVersion
         self.requirements = requirements
@@ -30,7 +61,7 @@ public struct CompatibilityInfo: Equatable {
     }
 
     /// Requirements which are compatible with the pinned version of this dependency
-    public var compatibleRequirements: [Dependency: VersionSpecifier] {
+    public var compatibleRequirements: [Dependency?: VersionSpecifier] {
         return requirements.filter { dependency, versionSpecifier in
             let effectiveVersionSpecifier = (try? versionSpecifier.effectiveSpecifier(for: self.dependency, retriever: projectDependencyRetriever)) ?? versionSpecifier
             return effectiveVersionSpecifier.isSatisfied(by: pinnedVersion)
@@ -38,7 +69,7 @@ public struct CompatibilityInfo: Equatable {
     }
 
     /// Requirements which are not compatible with the pinned version of this dependency
-    public var incompatibleRequirements: [Dependency: VersionSpecifier] {
+    public var incompatibleRequirements: [Dependency?: VersionSpecifier] {
         return requirements.filter { dependency, versionSpecifier in
             let effectiveVersionSpecifier = (try? versionSpecifier.effectiveSpecifier(for: self.dependency, retriever: projectDependencyRetriever)) ?? versionSpecifier
             return !effectiveVersionSpecifier.isSatisfied(by: pinnedVersion)
@@ -48,17 +79,17 @@ public struct CompatibilityInfo: Equatable {
     /// Accepts a dictionary which maps a dependency to the pinned versions of the dependencies it requires.
     /// Returns an inverted dictionary which maps a dependency to the dependencies that require it and the pinned version required
     /// e.g. [A: [B: 1, C: 2]] -> [B: [A: 1], C: [A: 2]]
-    public static func invert(requirements: Requirements) -> Result<Requirements, CarthageError> {
-        var invertedRequirements: Requirements = [:]
-        for (dependency, requirements) in requirements {
+    public static func invert(requirements: Requirements) -> Result<[Dependency: [Dependency?: VersionSpecifier]], CarthageError> {
+        var invertedRequirements = [Dependency: [Dependency?: VersionSpecifier]]()
+        for (definingDependency, requirements) in requirements.lookupTable {
             for (requiredDependency, requiredVersion) in requirements {
                 var requirements = invertedRequirements[requiredDependency] ?? [:]
 
-                if requirements[dependency] != nil {
-                    return .init(error: .duplicateDependencies([DuplicateDependency(dependency: dependency, locations: [])]))
+                if requirements[definingDependency] != nil {
+                    return .init(error: .duplicateDependencies([DuplicateDependency(dependency: requiredDependency, locations: [])]))
                 }
 
-                requirements[dependency] = requiredVersion
+                requirements[definingDependency] = requiredVersion
                 invertedRequirements[requiredDependency] = requirements
             }
         }
@@ -71,7 +102,7 @@ public struct CompatibilityInfo: Equatable {
         return CompatibilityInfo.invert(requirements: requirements)
             .map { invertedRequirements -> [CompatibilityInfo] in
                 return dependencies.compactMap { dependency, version in
-                    if version.isSemantic, let requirements = invertedRequirements[dependency] {
+                    if let requirements = invertedRequirements[dependency] {
                         return CompatibilityInfo(dependency: dependency, pinnedVersion: version, requirements: requirements, projectDependencyRetriever: projectDependencyRetriever)
                     }
                     return nil

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -400,9 +400,9 @@ extension CarthageError: CustomStringConvertible {
                 .flatMap { incompatibility -> [String] in
                     let sortedRequirements = incompatibility
                         .incompatibleRequirements
-                        .sorted { $0.0.name < $1.0.name }
+                        .sorted { ($0.0?.name ?? "") < ($1.0?.name ?? "") }
                     return sortedRequirements.map { dependency, versionSpecifier in
-                        return "* \(incompatibility.dependency.name) \(incompatibility.pinnedVersion) is incompatible with the version constraint specified by \(dependency.name): \(versionSpecifier)"
+                        return "* \(incompatibility.dependency.name) \(incompatibility.pinnedVersion) is incompatible with the version constraint specified by \(dependency?.name ?? "\(Constants.Project.cartfilePath)/\(Constants.Project.privateCartfilePath)"): \(versionSpecifier)"
                     }
                 }
                 .joined(separator: "\n")

--- a/Tests/CarthageKitTests/ResolverTests.swift
+++ b/Tests/CarthageKitTests/ResolverTests.swift
@@ -482,6 +482,8 @@ class ResolverTests: XCTestCase {
         let repository = LocalDependencyStore(directoryURL: repositoryURL)
         
         do {
+            let cartfile = try Cartfile.from(file: testCartfileURL).get()
+
             guard let resolvedCartfile1 = try project.resolveUpdatedDependencies(from: repository,
                                                                                  resolverType: resolverType.self,
                                                                                  dependenciesToUpdate: nil).first()?.get() else {
@@ -504,7 +506,7 @@ class ResolverTests: XCTestCase {
             expect(pinnedVersionSecurity1.semanticVersion) == SemanticVersion(2, 1, 0)
             
             // Test whether the resolved cartfile is valid (should be the case)
-            try project.validate(resolvedCartfile: resolvedCartfile1, dependencyRetriever: repository).first()?.get()
+            try project.validate(cartfile: cartfile, resolvedCartfile: resolvedCartfile1, dependencyRetriever: repository).first()?.get()
             
             // Now resolve only Security, should yield the same result
             
@@ -530,7 +532,7 @@ class ResolverTests: XCTestCase {
             expect(pinnedVersionSecurity2.semanticVersion) == SemanticVersion(2, 1, 0)
             
             // Test whether the resolved cartfile is valid (should be the case)
-            try project.validate(resolvedCartfile: resolvedCartfile2, dependencyRetriever: repository).first()?.get()
+            try project.validate(cartfile: cartfile, resolvedCartfile: resolvedCartfile2, dependencyRetriever: repository).first()?.get()
             
         } catch {
             fail("Expected no error to be thrown, but got: \(error)")


### PR DESCRIPTION
Before only Cartfile.resolved was validated. Incompatibilities between the Cartfile.resolved and Cartfile/Cartfile.private did not trigger a validation error. This has been resolved with this Pull Request.