### PR TITLE
prevent matchURL from getting stuck in an endless loop

### DIFF
--- a/Source/CarthageKit/DebugSymbolsMapper.swift
+++ b/Source/CarthageKit/DebugSymbolsMapper.swift
@@ -75,6 +75,9 @@ final class DebugSymbolsMapper {
 
         while !matchURL.isRoot {
             let lastPathComponent = matchURL.lastPathComponent
+            if lastPathComponent == ".." {
+                return nil
+            }
             trailingPathComponents.append(lastPathComponent)
             matchURL = matchURL.deletingLastPathComponent()
             let candidateURL = sourceURL.appendingPathComponents(trailingPathComponents.reversed())


### PR DESCRIPTION
The docs for URL.deletingLastPathComponent() include this: 
   /// This function may either remove a path component or append `/..`.
As a result, the while loop never exits and it just builds an ever longer file URL.