### PR TITLE
Fixed loops where deletingLastPathComponent was used

### DIFF
--- a/Source/CarthageKit/DebugSymbolsMapper.swift
+++ b/Source/CarthageKit/DebugSymbolsMapper.swift
@@ -73,9 +73,8 @@ final class DebugSymbolsMapper {
         var trailingPathComponents = [String]()
         var matchURL = buildSourceURL
 
-        while !matchURL.isRoot {
-            let lastPathComponent = matchURL.lastPathComponent
-            trailingPathComponents.append(lastPathComponent)
+        while !matchURL.isRoot && matchURL.lastPathComponent != ".." {
+            trailingPathComponents.append(matchURL.lastPathComponent)
             matchURL = matchURL.deletingLastPathComponent()
             let candidateURL = sourceURL.appendingPathComponents(trailingPathComponents.reversed())
             if candidateURL.isExistingFile {

--- a/Source/CarthageKit/FoundationExtensions.swift
+++ b/Source/CarthageKit/FoundationExtensions.swift
@@ -336,7 +336,7 @@ extension URL {
     internal func pathComponentsRelativeTo(_ baseURL: URL) -> [String]? {
         var url = self
         var relativeComponents = [String]()
-        while !url.path.isEmpty && url.path != "/" {
+        while !url.isRoot && url.lastPathComponent != ".." {
             if baseURL.resolvingSymlinksInPath().path == url.resolvingSymlinksInPath().path {
                 return relativeComponents.reversed()
             }
@@ -361,7 +361,7 @@ extension URL {
     internal func isAncestor(of url: URL) -> Bool {
         let path = self.resolvingSymlinksInPath().path
         var normalizedUrl = url.resolvingSymlinksInPath()
-        while !normalizedUrl.path.isEmpty && normalizedUrl.path != "/" {
+        while !normalizedUrl.isRoot && normalizedUrl.lastPathComponent != ".." {
             if normalizedUrl.path == path {
                 return true
             }


### PR DESCRIPTION
The loops could become infinite in case deletingLastPathComponent resulted in ".." being appended.
Now the three loops where this method is used are properly guarded against this condition.