### PR TITLE
Added option `--commitish` and `--project-name` to `build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ See [Installing Carthage](#installing-carthage)
 
 ## Change Log
 
+### 0.40.0+nsoperations
+
+- Added option `--commitish` and `--project-name` to the build command which can override the auto-detected git ref and project name to use when `--no-skip-current` is present for the project to build.
+
 ### 0.39.3+nsoperations
 
 - Fixed minor bug in .gitignore interpretation, specifically regarding leading spaces

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,5 +1,5 @@
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
     public let value: SemanticVersion
-    public static let current = CarthageKitVersion(value: SemanticVersion(0, 39, 3, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["nsoperations"]))
+    public static let current = CarthageKitVersion(value: SemanticVersion(0, 39, 4, prereleaseIdentifiers: ["beta"], buildMetadataIdentifiers: ["nsoperations"]))
 }

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,5 +1,5 @@
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
     public let value: SemanticVersion
-    public static let current = CarthageKitVersion(value: SemanticVersion(0, 39, 4, prereleaseIdentifiers: ["beta"], buildMetadataIdentifiers: ["nsoperations"]))
+    public static let current = CarthageKitVersion(value: SemanticVersion(0, 40, 0, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["nsoperations"]))
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -243,7 +243,7 @@ public final class Project { // swiftlint:disable:this type_body_length
             .then(SignalProducer<(), CarthageError>.empty)
     }
 
-    public func build(includingSelf: Bool, dependenciesToBuild: [String]?, buildOptions: BuildOptions, customCommitish: String?) -> BuildSchemeProducer {
+    public func build(includingSelf: Bool, dependenciesToBuild: [String]?, buildOptions: BuildOptions, customProjectName: String?, customCommitish: String?) -> BuildSchemeProducer {
         let buildProducer = self.loadResolvedCartfile()
             .map { _ in self }
             .flatMapError { error -> SignalProducer<Project, CarthageError> in
@@ -262,7 +262,7 @@ public final class Project { // swiftlint:disable:this type_body_length
         if !includingSelf {
             return buildProducer
         } else {
-            let currentProducers = Xcode.buildInDirectory(directoryURL, withOptions: buildOptions, rootDirectoryURL: directoryURL, lockTimeout: self.lockTimeout, customCommitish: customCommitish)
+            let currentProducers = Xcode.buildInDirectory(directoryURL, withOptions: buildOptions, rootDirectoryURL: directoryURL, lockTimeout: self.lockTimeout, customProjectName: customProjectName, customCommitish: customCommitish)
                 .flatMapError { error -> BuildSchemeProducer in
                     switch error {
                     case let .noSharedFrameworkSchemes(project, _):

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -49,13 +49,13 @@ public enum ProjectEvent {
     case skippedBuildingCached(Dependency)
 
     /// Rebuilding a cached project because of a version file/framework mismatch.
-    case rebuildingCached(Dependency)
+    case rebuildingCached(Dependency, VersionStatus)
 
     /// Building an uncached project.
     case buildingUncached(Dependency)
 
     /// Rebuilding because the installed binary is not valid
-    case rebuildingBinary(Dependency)
+    case rebuildingBinary(Dependency, VersionStatus)
 
     /// Waiting for a lock on the specified URL.
     case waiting(URL)
@@ -626,7 +626,7 @@ public final class Project { // swiftlint:disable:this type_body_length
             .flatMap(.concat) { resolvedCartfile -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
                 return self.buildOrderForResolvedCartfile(resolvedCartfile, dependenciesToInclude: dependenciesToBuild)
             }
-            .flatMap(.concat) { arg -> SignalProducer<((Dependency, PinnedVersion), Set<Dependency>, Bool?), CarthageError> in
+            .flatMap(.concat) { arg -> SignalProducer<((Dependency, PinnedVersion), Set<Dependency>, VersionStatus), CarthageError> in
                 let (dependency, version) = arg
                 return SignalProducer.combineLatest(
                     SignalProducer(value: (dependency, version)),
@@ -635,7 +635,7 @@ public final class Project { // swiftlint:disable:this type_body_length
                 )
             }
             .reduce([]) { includedDependencies, nextGroup -> [(Dependency, PinnedVersion)] in
-                let (nextDependency, projects, matches) = nextGroup
+                let (nextDependency, projects, versionStatus) = nextGroup
 
                 var dependenciesIncludingNext = includedDependencies
                 dependenciesIncludingNext.append(nextDependency)
@@ -646,16 +646,14 @@ public final class Project { // swiftlint:disable:this type_body_length
                     return dependenciesIncludingNext
                 }
 
-                guard let versionFileMatches = matches else {
+                if versionStatus == .versionFileNotFound {
                     self.projectEventsObserver.send(value: .buildingUncached(nextDependency.0))
                     return dependenciesIncludingNext
-                }
-
-                if versionFileMatches {
+                } else if versionStatus == .matching {
                     self.projectEventsObserver.send(value: .skippedBuildingCached(nextDependency.0))
                     return includedDependencies
                 } else {
-                    self.projectEventsObserver.send(value: .rebuildingCached(nextDependency.0))
+                    self.projectEventsObserver.send(value: .rebuildingCached(nextDependency.0, versionStatus))
                     return dependenciesIncludingNext
                 }
             }
@@ -682,7 +680,7 @@ public final class Project { // swiftlint:disable:this type_body_length
                         return self.symlinkBuildPathIfNeeded(for: dependency, version: version)
                             .then(.init(value: (dependency, version)))
                     }
-                    .flatMap(.merge) { dependency, version -> SignalProducer<(Dependency, PinnedVersion, Bool?), CarthageError> in
+                    .flatMap(.merge) { dependency, version -> SignalProducer<(Dependency, PinnedVersion, VersionStatus), CarthageError> in
                         return VersionFile.versionFileMatches(
                             dependency,
                             version: version,
@@ -694,9 +692,9 @@ public final class Project { // swiftlint:disable:this type_body_length
                             )
                             .map { matches in return (dependency, version, matches) }
                     }
-                    .filterMap { dependency, version, matches -> (Dependency, PinnedVersion)? in
-                        guard let versionFileMatches = matches, versionFileMatches else {
-                            self.projectEventsObserver.send(value: .rebuildingBinary(dependency))
+                    .filterMap { dependency, version, versionStatus -> (Dependency, PinnedVersion)? in
+                        guard versionStatus == .matching else {
+                            self.projectEventsObserver.send(value: .rebuildingBinary(dependency, versionStatus))
                             return nil
                         }
                         return (dependency, version)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -243,7 +243,7 @@ public final class Project { // swiftlint:disable:this type_body_length
             .then(SignalProducer<(), CarthageError>.empty)
     }
 
-    public func build(includingSelf: Bool, dependenciesToBuild: [String]?, buildOptions: BuildOptions) -> BuildSchemeProducer {
+    public func build(includingSelf: Bool, dependenciesToBuild: [String]?, buildOptions: BuildOptions, customCommitish: String?) -> BuildSchemeProducer {
         let buildProducer = self.loadResolvedCartfile()
             .map { _ in self }
             .flatMapError { error -> SignalProducer<Project, CarthageError> in
@@ -262,7 +262,7 @@ public final class Project { // swiftlint:disable:this type_body_length
         if !includingSelf {
             return buildProducer
         } else {
-            let currentProducers = Xcode.buildInDirectory(directoryURL, withOptions: buildOptions, rootDirectoryURL: directoryURL, lockTimeout: self.lockTimeout)
+            let currentProducers = Xcode.buildInDirectory(directoryURL, withOptions: buildOptions, rootDirectoryURL: directoryURL, lockTimeout: self.lockTimeout, customCommitish: customCommitish)
                 .flatMapError { error -> BuildSchemeProducer in
                     switch error {
                     case let .noSharedFrameworkSchemes(project, _):

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -317,6 +317,7 @@ extension VersionFile {
     ///
     /// Returns a signal that succeeds once the file has been created.
     static func createVersionFileForCurrentProject(
+        projectName: String?,
         commitish: String?,
         platforms: Set<Platform>,
         configuration: String,
@@ -324,7 +325,7 @@ extension VersionFile {
         rootDirectoryURL: URL
         ) -> SignalProducer<(), CarthageError> {
 
-        let currentProjectName = Dependencies.fetchDependencyNameForRepository(at: rootDirectoryURL)
+        let currentProjectName: SignalProducer<String, CarthageError>
         let currentGitTagOrCommitish: SignalProducer<String, CarthageError>
         
         if let customCommitish = commitish {
@@ -337,6 +338,12 @@ extension VersionFile {
                         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                         .flatMapError { _  in SignalProducer(value: headCommitish) }
             }
+        }
+        
+        if let customProjectName = projectName {
+            currentProjectName = SignalProducer<String, CarthageError>(value: customProjectName)
+        } else {
+            currentProjectName = Dependencies.fetchDependencyNameForRepository(at: rootDirectoryURL)
         }
 
         return SignalProducer.zip(currentProjectName, currentGitTagOrCommitish)

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -20,6 +20,26 @@ struct CachedFramework: Codable {
     }
 }
 
+public enum VersionStatus {
+    case matching
+    case versionFileNotFound
+    case sourceHashNotEqual
+    case configurationNotEqual
+    case commitishNotEqual
+    case platformNotFound
+    case swiftVersionNotEqual
+    case binaryHashNotEqual
+    case binaryHashCalculationFailed
+}
+
+func &&(lhs: VersionStatus, rhs: VersionStatus) -> VersionStatus {
+    if lhs == .matching {
+        return rhs
+    } else {
+        return lhs
+    }
+}
+
 struct VersionFile: Codable {
 
     static let sourceHashCache = Cache<URL, String>()
@@ -190,10 +210,10 @@ struct VersionFile: Codable {
         configuration: String,
         binariesDirectoryURL: URL,
         localSwiftVersion: PinnedVersion
-        ) -> SignalProducer<Bool, CarthageError> {
+        ) -> SignalProducer<VersionStatus, CarthageError> {
         let platformsToCheck = platforms.isEmpty ? Set<Platform>(Platform.supportedPlatforms) : platforms
         return SignalProducer<Platform, CarthageError>(platformsToCheck)
-            .flatMap(.merge) { platform -> SignalProducer<Bool, CarthageError> in
+            .flatMap(.merge) { platform -> SignalProducer<VersionStatus, CarthageError> in
                 return self.satisfies(
                     platform: platform,
                     commitish: commitish,
@@ -203,7 +223,7 @@ struct VersionFile: Codable {
                     localSwiftVersion: localSwiftVersion
                 )
             }
-            .reduce(true) { $0 && $1 }
+            .reduce(VersionStatus.matching) { $0 && $1 }
     }
 
     func satisfies(
@@ -213,9 +233,9 @@ struct VersionFile: Codable {
         configuration: String,
         binariesDirectoryURL: URL,
         localSwiftVersion: PinnedVersion
-        ) -> SignalProducer<Bool, CarthageError> {
+        ) -> SignalProducer<VersionStatus, CarthageError> {
         guard let cachedFrameworks = self[platform] else {
-            return SignalProducer(value: false)
+            return SignalProducer(value: .platformNotFound)
         }
 
         let hashes = self.hashes(
@@ -233,7 +253,7 @@ struct VersionFile: Codable {
             .collect()
 
         return SignalProducer.zip(hashes, swiftVersionMatches)
-            .flatMap(.concat) { hashes, swiftVersionMatches -> SignalProducer<Bool, CarthageError> in
+            .flatMap(.concat) { hashes, swiftVersionMatches -> SignalProducer<VersionStatus, CarthageError> in
                 return self.satisfies(
                     platform: platform,
                     commitish: commitish,
@@ -252,16 +272,22 @@ struct VersionFile: Codable {
         configuration: String,
         hashes: [String?],
         swiftVersionMatches: [Bool]
-        ) -> SignalProducer<Bool, CarthageError> {
+        ) -> SignalProducer<VersionStatus, CarthageError> {
         
         if let definedSourceHash = self.sourceHash, let suppliedSourceHash = sourceHash, definedSourceHash != suppliedSourceHash {
-            print("Source hash does not match")
-            return SignalProducer(value: false)
+            return SignalProducer(value: .sourceHashNotEqual)
+        }
+        
+        guard let cachedFrameworks = self[platform] else {
+            return SignalProducer(value: .platformNotFound)
         }
 
-        guard let cachedFrameworks = self[platform], commitish == self.commitish, configuration == self.configuration else {
-            print("Commit hash or configuration do not match")
-            return SignalProducer(value: false)
+        guard commitish == self.commitish else {
+            return SignalProducer(value: .commitishNotEqual)
+        }
+        
+        guard configuration == self.configuration else {
+            return SignalProducer(value: .configurationNotEqual)
         }
 
         return SignalProducer
@@ -270,22 +296,19 @@ struct VersionFile: Codable {
                 SignalProducer(cachedFrameworks),
                 SignalProducer(swiftVersionMatches)
             )
-            .map { hash, cachedFramework, swiftVersionMatches -> Bool in
+            .map { hash, cachedFramework, swiftVersionMatches -> VersionStatus in
                 if let hash = hash {
                     if !swiftVersionMatches {
-                        print("Swift version does not match")
+                        return .swiftVersionNotEqual
                     } else if hash != cachedFramework.hash {
-                        print("Binary hash does not match")
+                        return .binaryHashNotEqual
                     }
-                    return hash == cachedFramework.hash && swiftVersionMatches
+                    return .matching
                 } else {
-                    print("Binary hash does not exist")
-                    return false
+                    return .binaryHashCalculationFailed
                 }
             }
-            .reduce(true) { result, current -> Bool in
-                return result && current
-        }
+            .reduce(VersionStatus.matching) { $0 && $1 }
     }
 
     func write(to url: URL) -> Result<(), CarthageError> {
@@ -490,10 +513,10 @@ extension VersionFile {
         rootDirectoryURL: URL,
         toolchain: String?,
         checkSourceHash: Bool
-        ) -> SignalProducer<Bool?, CarthageError> {
+        ) -> SignalProducer<VersionStatus, CarthageError> {
         let versionFileURL = self.versionFileURL(dependencyName: dependency.name, rootDirectoryURL: rootDirectoryURL)
         guard let versionFile = VersionFile(url: versionFileURL) else {
-            return SignalProducer(value: nil)
+            return SignalProducer(value: .versionFileNotFound)
         }
         let rootBinariesURL = versionFileURL.deletingLastPathComponent()
         let commitish = version.commitish
@@ -501,14 +524,13 @@ extension VersionFile {
         return SwiftToolchain.swiftVersion(usingToolchain: toolchain)
             .mapError { error in CarthageError.internalError(description: error.description) }
             .combineLatest(with: checkSourceHash ? self.sourceHash(dependencyName: dependency.name, rootDirectoryURL: rootDirectoryURL) : SignalProducer<String?, CarthageError>(value: nil))
-            .flatMap(.concat) { localSwiftVersion, sourceHash in
+            .flatMap(.concat) { localSwiftVersion, sourceHash -> SignalProducer<VersionStatus, CarthageError> in
                 return versionFile.satisfies(platforms: platforms,
                                              commitish: commitish,
                                              sourceHash: sourceHash,
                                              configuration: configuration,
                                              binariesDirectoryURL: rootBinariesURL,
                                              localSwiftVersion: localSwiftVersion)
-                    .map { .some($0) }
         }
     }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -63,6 +63,7 @@ public final class Xcode {
         dependency: (dependency: Dependency, version: PinnedVersion)? = nil,
         rootDirectoryURL: URL,
         lockTimeout: Int? = nil,
+        customProjectName: String? = nil,
         customCommitish: String? = nil,
         sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) },
         builtProductsHandler: (([URL]) -> SignalProducer<(), CarthageError>)? = nil
@@ -131,6 +132,7 @@ public final class Xcode {
                                 // Is only possible if the current project is a git repository, because the version file is tied to commit hash
                                 if rootDirectoryURL.isGitDirectory {
                                     return VersionFile.createVersionFileForCurrentProject(
+                                        projectName: customProjectName, 
                                         commitish: customCommitish,
                                         platforms: options.platforms,
                                         configuration: options.configuration,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -63,6 +63,7 @@ public final class Xcode {
         dependency: (dependency: Dependency, version: PinnedVersion)? = nil,
         rootDirectoryURL: URL,
         lockTimeout: Int? = nil,
+        customCommitish: String? = nil,
         sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) },
         builtProductsHandler: (([URL]) -> SignalProducer<(), CarthageError>)? = nil
         ) -> BuildSchemeProducer {
@@ -130,6 +131,7 @@ public final class Xcode {
                                 // Is only possible if the current project is a git repository, because the version file is tied to commit hash
                                 if rootDirectoryURL.isGitDirectory {
                                     return VersionFile.createVersionFileForCurrentProject(
+                                        commitish: customCommitish,
                                         platforms: options.platforms,
                                         configuration: options.configuration,
                                         buildProducts: urls,

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -49,6 +49,7 @@ public struct BuildCommand: CommandProtocol {
         public let archive: Bool
         public let archiveOutputPath: String?
         public let lockTimeout: Int?
+        public let customProjectName: String?
         public let customCommitish: String?
         public let dependenciesToBuild: [String]?
 
@@ -78,7 +79,8 @@ public struct BuildCommand: CommandProtocol {
                 usage: "the path at which to create the archive zip file (or blank to infer it from the first one of the framework names)"
             )
             let option7 = Option<Int?>(key: "lock-timeout", defaultValue: nil, usage: "timeout in seconds to wait for an exclusive lock on shared files, defaults to no timeout")
-            let option8 = Option<String?>(key: "commitish", defaultValue: nil, usage: "the optional custom commitish to use when writing the version file if --no-skip-current is present. If not supplied the current git state of the working tree is inspected to auto-detect the commitish to use.")
+            let option8 = Option<String?>(key: "project-name", defaultValue: nil, usage: "the optional project name to use when writing the version file if --no-skip-current is present. If not supplied the current git state of the working tree is inspected to auto-detect the project name to use from the list of remotes.")
+            let option9 = Option<String?>(key: "commitish", defaultValue: nil, usage: "the optional custom commitish to use when writing the version file if --no-skip-current is present. If not supplied the current git state of the working tree is inspected to auto-detect the commitish to use which is either a tag or commit hash.")
 
             return curry(self.init)
                 <*> BuildOptions.evaluate(mode)
@@ -91,6 +93,7 @@ public struct BuildCommand: CommandProtocol {
                 <*> mode <| option6
                 <*> mode <| option7
                 <*> mode <| option8
+                <*> mode <| option9
                 <*> (mode <| Argument(defaultValue: [], usage: "the dependency names to build", usageParameter: "dependency names")).map { $0.isEmpty ? nil : $0 }
         }
     }
@@ -121,7 +124,7 @@ public struct BuildCommand: CommandProtocol {
                 let shouldBuildCurrentProject =  !options.skipCurrent || options.archive
 
                 project.lockTimeout = options.lockTimeout
-                let buildProgress = project.build(includingSelf: shouldBuildCurrentProject, dependenciesToBuild: options.dependenciesToBuild, buildOptions: options.buildOptions, customCommitish: options.customCommitish)
+                let buildProgress = project.build(includingSelf: shouldBuildCurrentProject, dependenciesToBuild: options.dependenciesToBuild, buildOptions: options.buildOptions, customProjectName: options.customProjectName, customCommitish: options.customCommitish)
 
                 let stderrHandle = options.isVerbose ? FileHandle.standardError : stdoutHandle
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -49,6 +49,7 @@ public struct BuildCommand: CommandProtocol {
         public let archive: Bool
         public let archiveOutputPath: String?
         public let lockTimeout: Int?
+        public let customCommitish: String?
         public let dependenciesToBuild: [String]?
 
         /// If `archive` is true, this will be a producer that will archive
@@ -77,6 +78,7 @@ public struct BuildCommand: CommandProtocol {
                 usage: "the path at which to create the archive zip file (or blank to infer it from the first one of the framework names)"
             )
             let option7 = Option<Int?>(key: "lock-timeout", defaultValue: nil, usage: "timeout in seconds to wait for an exclusive lock on shared files, defaults to no timeout")
+            let option8 = Option<String?>(key: "commitish", defaultValue: nil, usage: "the optional custom commitish to use when writing the version file if --no-skip-current is present. If not supplied the current git state of the working tree is inspected to auto-detect the commitish to use.")
 
             return curry(self.init)
                 <*> BuildOptions.evaluate(mode)
@@ -88,6 +90,7 @@ public struct BuildCommand: CommandProtocol {
                 <*> mode <| option5
                 <*> mode <| option6
                 <*> mode <| option7
+                <*> mode <| option8
                 <*> (mode <| Argument(defaultValue: [], usage: "the dependency names to build", usageParameter: "dependency names")).map { $0.isEmpty ? nil : $0 }
         }
     }
@@ -118,7 +121,7 @@ public struct BuildCommand: CommandProtocol {
                 let shouldBuildCurrentProject =  !options.skipCurrent || options.archive
 
                 project.lockTimeout = options.lockTimeout
-                let buildProgress = project.build(includingSelf: shouldBuildCurrentProject, dependenciesToBuild: options.dependenciesToBuild, buildOptions: options.buildOptions)
+                let buildProgress = project.build(includingSelf: shouldBuildCurrentProject, dependenciesToBuild: options.dependenciesToBuild, buildOptions: options.buildOptions, customCommitish: options.customCommitish)
 
                 let stderrHandle = options.isVerbose ? FileHandle.standardError : stdoutHandle
 

--- a/Source/carthage/Logger.swift
+++ b/Source/carthage/Logger.swift
@@ -60,17 +60,17 @@ final class ProjectEventLogger {
         case let .skippedBuildingCached(dependency):
             carthage.println(formatting.bullets + "Valid cache found for " + formatting.projectName(dependency.name) + ", skipping build")
 
-        case let .rebuildingCached(dependency):
+        case let .rebuildingCached(dependency, versionStatus):
             carthage.println(formatting.bullets + "Invalid cache found for " + formatting.projectName(dependency.name)
-                + ", rebuilding with all downstream dependencies")
+                + " because \(versionStatus.humanReadableDescription), rebuilding with all downstream dependencies")
 
         case let .buildingUncached(dependency):
             carthage.println(formatting.bullets + "No cache found for " + formatting.projectName(dependency.name)
                 + ", building with all downstream dependencies")
 
-        case let .rebuildingBinary(dependency):
+        case let .rebuildingBinary(dependency, versionStatus):
             carthage.println(formatting.bullets + "Invalid binary found for " + formatting.projectName(dependency.name)
-                + ", rebuilding with all downstream dependencies")
+                + " because \(versionStatus.humanReadableDescription), rebuilding with all downstream dependencies")
 
         case let .waiting(url):
             carthage.println(formatting.bullets + "Waiting for lock on " + url.path)
@@ -105,6 +105,31 @@ final class ResolverEventLogger {
             if isVerbose {
                 carthage.println("Rejected dependency set:\n\(dependencySet)\n\nReason: \(error)\n")
             }
+        }
+    }
+}
+
+extension VersionStatus {
+    var humanReadableDescription: String {
+        switch self {
+        case .matching:
+            return ""
+        case .binaryHashCalculationFailed:
+            return "the binary checksum calculation failed"
+        case .binaryHashNotEqual:
+            return "the binary checksum did not match"
+        case .commitishNotEqual:
+            return "the commit hash or tag did not match"
+        case .configurationNotEqual:
+            return "the build configuration did not match"
+        case .platformNotFound:
+            return "one of the requested platforms was not found"
+        case .sourceHashNotEqual:
+            return "the source hash did not match"
+        case .swiftVersionNotEqual:
+            return "the swift version did not match the current toolchain"
+        case .versionFileNotFound:
+            return "the version file was not found"
         }
     }
 }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -29,6 +29,7 @@ public struct UpdateCommand: CommandProtocol {
                 archive: false,
                 archiveOutputPath: nil,
                 lockTimeout: checkoutOptions.lockTimeout,
+                customCommitish: nil,
                 dependenciesToBuild: dependenciesToUpdate
             )
         }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -29,6 +29,7 @@ public struct UpdateCommand: CommandProtocol {
                 archive: false,
                 archiveOutputPath: nil,
                 lockTimeout: checkoutOptions.lockTimeout,
+                customProjectName: nil,
                 customCommitish: nil,
                 dependenciesToBuild: dependenciesToUpdate
             )

--- a/Tests/CarthageKitTests/VersionFileTests.swift
+++ b/Tests/CarthageKitTests/VersionFileTests.swift
@@ -140,8 +140,12 @@ class VersionFileTests: XCTestCase {
     func validate(file: VersionFile, matches: Bool, platform: Platform, commitish: String, configuration: String = "Debug", hashes: [String?],
 				  swiftVersionMatches: [Bool], fileName: FileString = #file, line: UInt = #line) {
         _ = file.satisfies(platform: platform, commitish: commitish, sourceHash: nil, configuration: configuration, hashes: hashes, swiftVersionMatches: swiftVersionMatches)
-			.on(value: { didMatch in
-				expect(didMatch, file: fileName, line: line) == matches
+			.on(value: { versionStatus in
+                if matches {
+                    expect(versionStatus, file: fileName, line: line) == .matching
+                } else {
+                    expect(versionStatus, file: fileName, line: line) != .matching
+                }
 			})
 			.wait()
 	}


### PR DESCRIPTION
These options allow for overriding the auto-detected commitish and project name from the git working tree. Useful to specify a future tag when building or a custom project name if there are not yet any remotes configured.