### PR TITLE
Fixes for the validate command and source digest

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -155,9 +155,27 @@ public func duplicateDependenciesIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile
 public struct ResolvedCartfile {
     /// The dependencies listed in the Cartfile.resolved.
     public let dependencies: [Dependency: PinnedVersion]
+    private let dependenciesByName: [String: Dependency]
 
     public init(dependencies: [Dependency: PinnedVersion]) {
         self.dependencies = dependencies
+        var dependenciesByName = [String: Dependency]()
+        for (dependency, _) in dependencies {
+            dependenciesByName[dependency.name] = dependency
+        }
+        self.dependenciesByName = dependenciesByName
+    }
+
+    public func dependency(for name: String) -> Dependency? {
+        return dependenciesByName[name]
+    }
+
+    public func version(for name: String) -> PinnedVersion? {
+        if let dependency = dependency(for: name) {
+            return dependencies[dependency]
+        } else {
+            return nil
+        }
     }
 }
 

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -155,27 +155,9 @@ public func duplicateDependenciesIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile
 public struct ResolvedCartfile {
     /// The dependencies listed in the Cartfile.resolved.
     public let dependencies: [Dependency: PinnedVersion]
-    private let dependenciesByName: [String: Dependency]
 
     public init(dependencies: [Dependency: PinnedVersion]) {
         self.dependencies = dependencies
-        var dependenciesByName = [String: Dependency]()
-        for (dependency, _) in dependencies {
-            dependenciesByName[dependency.name] = dependency
-        }
-        self.dependenciesByName = dependenciesByName
-    }
-
-    public func dependency(for name: String) -> Dependency? {
-        return dependenciesByName[name]
-    }
-
-    public func version(for name: String) -> PinnedVersion? {
-        if let dependency = dependency(for: name) {
-            return dependencies[dependency]
-        } else {
-            return nil
-        }
     }
 }
 

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,5 +1,5 @@
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
     public let value: SemanticVersion
-    public static let current = CarthageKitVersion(value: SemanticVersion(0, 40, 0, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["nsoperations"]))
+    public static let current = CarthageKitVersion(value: SemanticVersion(0, 40, 1, prereleaseIdentifiers: ["beta"], buildMetadataIdentifiers: ["nsoperations"]))
 }

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -11,6 +11,9 @@ public struct Constants {
     /// to the working directory).
     public static let binariesFolderPath = "Carthage/Build"
 
+    /// The relative path to a project's checked out dependencies.
+    public static let checkoutsPath = "Carthage/Checkouts"
+
     /// The fallback dependencies URL to be used in case
     /// the intended ~/Library/Caches/org.carthage.CarthageKit cannot
     /// be found or created.

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -52,7 +52,7 @@ public enum Dependency: Hashable {
     }
 
     public static func relativePath(dependencyName: String) -> String {
-        return carthageProjectCheckoutsPath.appendingPathComponent(dependencyName)
+        return Constants.checkoutsPath.appendingPathComponent(dependencyName)
     }
 }
 

--- a/Source/CarthageKit/DependencySet.swift
+++ b/Source/CarthageKit/DependencySet.swift
@@ -228,7 +228,7 @@ final class DependencySet {
     }
 
     /**
-     Eliminates dependencies with duplicate names, keeping the most relevant once.
+     Eliminates dependencies with duplicate names, keeping the most relevant one.
 
      The carthage model does not allow two dependencies with the same name, this is because forks should be allowed to override their upstreams.
      */

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -89,7 +89,7 @@ public enum CarthageError: Error {
     case duplicateDependencies([DuplicateDependency])
 
     /// There was a cycle between dependencies in the associated graph.
-    case dependencyCycle([Dependency: Set<Dependency>])
+    case dependencyCycle([Dependency])
 
     /// A request to the GitHub API failed.
     case gitHubAPIRequestFailed(Client.Error)
@@ -350,17 +350,9 @@ extension CarthageError: CustomStringConvertible {
                 .joined(separator: "")
             return "The following dependencies are duplicates:\(deps)"
 
-        case let .dependencyCycle(graph):
-            let prettyGraph = graph
-                .map { project, dependencies in
-                    let prettyDependencies = dependencies
-                        .map { $0.name }
-                        .joined(separator: ", ")
+        case let .dependencyCycle(nodes):
 
-                    return "\(project.name): \(prettyDependencies)"
-                }
-                .joined(separator: "\n")
-
+            let prettyGraph = nodes.map({ $0.name }).joined(separator: " -> ")
             return "The dependency graph contained a cycle:\n\(prettyGraph)"
 
         case let .gitHubAPIRequestFailed(message):

--- a/Source/CarthageKit/FileOutputStream.swift
+++ b/Source/CarthageKit/FileOutputStream.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+class FileOutputStream: TextOutputStream {
+    private let fileHandle: FileHandle
+    private let encoding: String.Encoding
+    
+    convenience init(fileURL: URL, encoding: String.Encoding = .utf8) throws {
+        
+        let mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+        let fileDescriptor = open(fileURL.path, O_CREAT | O_WRONLY | O_TRUNC, mode)
+        
+        if fileDescriptor < 0 {
+            let posixErrorCode = POSIXErrorCode(rawValue: errno)!
+            throw POSIXError(posixErrorCode)
+        }
+        
+        let fileHandle = FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
+        self.init(fileHandle: fileHandle, encoding: encoding)
+    }
+    
+    init(fileHandle: FileHandle, encoding: String.Encoding = .utf8) {
+        self.fileHandle = fileHandle
+        self.encoding = encoding
+    }
+    
+    func write(_ string: String) {
+        if let data = string.data(using: encoding) {
+            fileHandle.write(data)
+        }
+    }
+}

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -181,7 +181,9 @@ public final class Git {
                 }
             }
             .flatMap(.concat) { environment in
-                return launchGitTask([ "checkout", "--quiet", "--force", revision ], repositoryFileURL: repositoryFileURL, environment: environment)
+                return launchGitTask([ "checkout", "--quiet", "--force", revision ], repositoryFileURL: repositoryFileURL, environment: environment).then(
+                    launchGitTask([ "clean", "-f", "-d", "-x"], repositoryFileURL: repositoryFileURL, environment: environment)
+                )
             }
             .then(SignalProducer<(), CarthageError>.empty)
     }

--- a/Source/CarthageKit/GitIgnore.swift
+++ b/Source/CarthageKit/GitIgnore.swift
@@ -15,6 +15,13 @@ final class GitIgnore {
     private var negatedPatterns = [Pattern]()
     private var patterns = [Pattern]()
     
+    var copy: GitIgnore {
+        let copy = GitIgnore(parent: self.parent)
+        copy.negatedPatterns = self.negatedPatterns
+        copy.patterns = self.patterns
+        return copy
+    }
+    
     init(parent: GitIgnore? = nil) {
         self.parent = parent
     }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -604,7 +604,7 @@ public final class Project { // swiftlint:disable:this type_body_length
                 // Added mapping from name -> Dependency based on the ResolvedCartfile because
                 // duplicate dependencies with the same name (e.g. github forks) should resolve to the same dependency.
                 let (dependency, version) = arg
-                return self.dependencyRetriever.dependencySet(for: dependency, version: version, mapping: { cartfile.dependency(for: $0.name) ?? $0 })
+                return self.dependencyRetriever.dependencySet(for: dependency, version: version)
                     .map { dependencies in
                         [dependency: dependencies]
                 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -468,7 +468,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 
         return SignalProducer(value: resolvedCartfile)
             .flatMap(.concat) { (resolved: ResolvedCartfile) -> SignalProducer<([Dependency: PinnedVersion], CompatibilityInfo.Requirements), CarthageError> in
-                let requirements = self.requirementsByDependency(cartfile: cartfile, resolvedCartfile: resolved, tryCheckoutDirectory: true, dependencyRetriever: effectiveDependencyRetriever)
+                let requirements = self.requirementsByDependency(cartfile: cartfile, resolvedCartfile: resolved, tryCheckoutDirectory: false, dependencyRetriever: effectiveDependencyRetriever)
                 return SignalProducer.zip(SignalProducer(value: resolved.dependencies), requirements)
             }
             .flatMap(.concat) { (info: ([Dependency: PinnedVersion], CompatibilityInfo.Requirements)) -> SignalProducer<[CompatibilityInfo], CarthageError> in

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -224,7 +224,11 @@ public final class Project { // swiftlint:disable:this type_body_length
                 let checkoutsFolder = self.directoryURL.appendingPathComponent(Constants.checkoutsPath)
                 let urls: [URL]
                 do {
-                    urls = try FileManager.default.contentsOfDirectory(at: checkoutsFolder, includingPropertiesForKeys: nil, options: [])
+                    if checkoutsFolder.isExistingDirectory {
+                        urls = try FileManager.default.contentsOfDirectory(at: checkoutsFolder, includingPropertiesForKeys: nil, options: [])
+                    } else {
+                        urls = [URL]()
+                    }
                 } catch {
                     throw CarthageError.readFailed(checkoutsFolder, error as NSError)
                 }

--- a/Source/CarthageKit/ProjectDependencyRetriever.swift
+++ b/Source/CarthageKit/ProjectDependencyRetriever.swift
@@ -113,17 +113,15 @@ public final class ProjectDependencyRetriever: DependencyRetrieverProtocol {
                     guard let nextDependency = unhandledSet.popFirst() else {
                         break
                     }
-                    if !resultSet.contains(nextDependency) {
-                        resultSet.insert(nextDependency)
-                        //Find the recursive dependencies for this value
-                        guard let nextVersion = dependencyVersions[nextDependency] else {
-                            // This is an internal inconsistency
-                            throw CarthageError.internalError(description: "Found transitive dependency \(nextDependency) which is not present in the Cartfile.resolved, which should never occur. Please perform a clean bootstrap.")
-                        }
-                        let nextSet = try transitiveDependencies(nextDependency, nextVersion)
-                        for transitiveDependency in nextSet where !resultSet.contains(transitiveDependency) {
-                            unhandledSet.insert(transitiveDependency)
-                        }
+                    resultSet.insert(nextDependency)
+                    //Find the recursive dependencies for this value
+                    guard let nextVersion = dependencyVersions[nextDependency] else {
+                        // This is an internal inconsistency
+                        throw CarthageError.internalError(description: "Found transitive dependency \(nextDependency) which is not present in the Cartfile.resolved, which should never occur. Please perform a clean bootstrap.")
+                    }
+                    let nextSet = try transitiveDependencies(nextDependency, nextVersion)
+                    for transitiveDependency in nextSet where !resultSet.contains(transitiveDependency) {
+                        unhandledSet.insert(transitiveDependency)
                     }
                 }
                 return .success(resultSet)

--- a/Source/CarthageKit/ProjectDependencyRetriever.swift
+++ b/Source/CarthageKit/ProjectDependencyRetriever.swift
@@ -122,8 +122,7 @@ public final class ProjectDependencyRetriever: DependencyRetrieverProtocol {
             if tryCheckoutDirectory {
                 let dependencyURL = self.directoryURL.appendingPathComponent(dependency.relativePath)
                 cartfileSource = SignalProducer<Bool, NoError> { () -> Bool in
-                    var isDirectory: ObjCBool = false
-                    return FileManager.default.fileExists(atPath: dependencyURL.path, isDirectory: &isDirectory) && isDirectory.boolValue
+                        return dependencyURL.isExistingDirectory
                     }
                     .flatMap(.concat) { directoryExists -> SignalProducer<Cartfile, CarthageError> in
                         if directoryExists {

--- a/Source/CarthageKit/SHA256Digest.swift
+++ b/Source/CarthageKit/SHA256Digest.swift
@@ -99,24 +99,12 @@ class Digest {
      */
     class func digestForDirectoryAtURL(_ directoryURL: URL, parentGitIgnore: GitIgnore? = nil) -> Result<Data, CarthageError> {
         do {
-            let lastPathComponent = directoryURL.lastPathComponent
-            let timeStamp = Int64(Date().timeIntervalSince1970)
-            let logFileURL = URL(fileURLWithPath: "/tmp/carthage/\(lastPathComponent)-\(timeStamp)-digest.log")
-            print("Writing digest log to: \(logFileURL.path)")
-            var output = try FileOutputStream(fileURL: logFileURL)
-            print("Calculating digest for directory: \(directoryURL.path)", to: &output)
-            
             let digest = self.init()
             try crawl(directoryURL, relativePath: nil, parentGitIgnore: parentGitIgnore) { fileURL, relativePath in
 
                 guard let inputStream = InputStream(url: fileURL) else {
                     throw CarthageError.readFailed(fileURL, nil)
                 }
-                
-                let fileDigest = type(of: digest).digestForFileAtURL(fileURL)
-                
-                print("\(relativePath): \(fileDigest.value?.hexString ?? fileDigest.error!.description)", to: &output)
-                
                 //calculate hash
                 do {
                     try digest.update(inputStream: inputStream)
@@ -125,7 +113,6 @@ class Digest {
                 }
             }
             let result = digest.finalize()
-            print("Final computed digest: \(result)", to: &output)
             return .success(result)
         } catch let error as CarthageError {
             return .failure(error)
@@ -224,35 +211,5 @@ final class MD5Digest: Digest {
         var resultBuffer = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
         CC_MD5_Final(&resultBuffer, &self.context)
         return Data(bytes: resultBuffer)
-    }
-}
-
-fileprivate class FileOutputStream: TextOutputStream {
-    private let fileHandle: FileHandle
-    private let encoding: String.Encoding
-    
-    convenience init(fileURL: URL, encoding: String.Encoding = .utf8) throws {
-        
-        let mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
-        let fileDescriptor = open(fileURL.path, O_CREAT | O_WRONLY | O_TRUNC, mode)
-        
-        if fileDescriptor < 0 {
-            let posixErrorCode = POSIXErrorCode(rawValue: errno)!
-            throw POSIXError(posixErrorCode)
-        }
-        
-        let fileHandle = FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
-        self.init(fileHandle: fileHandle, encoding: encoding)
-    }
-    
-    init(fileHandle: FileHandle, encoding: String.Encoding = .utf8) {
-        self.fileHandle = fileHandle
-        self.encoding = encoding
-    }
-    
-    func write(_ string: String) {
-        if let data = string.data(using: encoding) {
-            fileHandle.write(data)
-        }
     }
 }

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -579,12 +579,13 @@ extension VersionFile {
 
         # User-specific Xcode files
         **/xcuserdata/**
-        **/*.xccheckout
+        *.xccheckout
         *.xcscmblueprint
 
-        # Do not track schemes, because auto-generate schemes would invalidate the source hash
+        # Do not track schemes, to avoid cache invalidation with scheme auto-generation on
         *.xcscheme
         IDEWorkspaceChecks.plist
+        WorkspaceSettings.xcsettings
 
         # Temporary files
         *.swp

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -103,12 +103,15 @@ struct VersionFile: Codable {
     init?(url: URL) {
         guard
             FileManager.default.fileExists(atPath: url.path),
-            let jsonData = try? Data(contentsOf: url),
-            let versionFile = try? JSONDecoder().decode(VersionFile.self, from: jsonData) else
+            let jsonData = try? Data(contentsOf: url) else
         {
             return nil
         }
-        self = versionFile
+        try? self.init(jsonData: jsonData)
+    }
+
+    init(jsonData: Data) throws {
+        self = try JSONDecoder().decode(VersionFile.self, from: jsonData)
     }
 
     func frameworkURL(

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -36,7 +36,7 @@ extension ProjectLocator {
 
         return Git.gitmodulesEntriesInRepository(directoryURL, revision: nil)
             .map { directoryURL.appendingPathComponent($0.path) }
-            .concat(value: directoryURL.appendingPathComponent(carthageProjectCheckoutsPath))
+            .concat(value: directoryURL.appendingPathComponent(Constants.checkoutsPath))
             .collect()
             .flatMap(.merge) { directoriesToSkip -> SignalProducer<URL, CarthageError> in
                 return FileManager.default.reactive

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -867,7 +867,7 @@ public final class Xcode {
 
                         // Do not copy build products that originate from the current project's own carthage dependencies
                         let projectURL = URL(fileURLWithPath: projectPath)
-                        let dependencyCheckoutDir = workingDirectoryURL.appendingPathComponent(carthageProjectCheckoutsPath, isDirectory: true)
+                        let dependencyCheckoutDir = workingDirectoryURL.appendingPathComponent(Constants.checkoutsPath, isDirectory: true)
                         return !dependencyCheckoutDir.hasSubdirectory(projectURL)
                     }
                     .flatMap(.concat) { settings in resolveSameTargetName(for: settings) }

--- a/Tests/CarthageKitTests/AlgorithmsTests.swift
+++ b/Tests/CarthageKitTests/AlgorithmsTests.swift
@@ -29,8 +29,8 @@ class AlgorithmTests: XCTestCase {
 		malformedGraph["A"] = Set(["B"])
 	}
 	
-	func testShouldSortFirstByDependencyAndSecondByComparability() {
-		let sorted = Algorithms.topologicalSort(validGraph)
+	func testShouldSortFirstByDependencyAndSecondByComparability() throws {
+        let sorted = try Algorithms.topologicalSort(validGraph).get()
 		
 		expect(sorted) == [
 			"Argo",
@@ -43,8 +43,8 @@ class AlgorithmTests: XCTestCase {
 		]
 	}
 	
-	func testShouldOnlyIncludeTheProvidedNodeAndItsTransitiveDependencies1() {
-		let sorted = Algorithms.topologicalSort(validGraph, nodes: Set(["ReactiveTask"]))
+	func testShouldOnlyIncludeTheProvidedNodeAndItsTransitiveDependencies1() throws {
+        let sorted = try Algorithms.topologicalSort(validGraph, nodes: Set(["ReactiveTask"])).get()
 		
 		expect(sorted) == [
 			"Result",
@@ -53,8 +53,8 @@ class AlgorithmTests: XCTestCase {
 		]
 	}
 	
-	func testShouldOnlyIncludeProvidedNodesAndTheirTransitiveDependencies2() {
-		let sorted = Algorithms.topologicalSort(validGraph, nodes: Set(["ReactiveTask", "Commandant"]))
+	func testShouldOnlyIncludeProvidedNodesAndTheirTransitiveDependencies2() throws {
+        let sorted = try Algorithms.topologicalSort(validGraph, nodes: Set(["ReactiveTask", "Commandant"])).get()
 		
 		expect(sorted) == [
 			"Result",
@@ -64,8 +64,8 @@ class AlgorithmTests: XCTestCase {
 		]
 	}
 	
-	func testShouldOnlyIncludeProvidedNodesAndTheirTransitiveDependencies3() {
-		let sorted = Algorithms.topologicalSort(validGraph, nodes: Set(["Carthage"]))
+	func testShouldOnlyIncludeProvidedNodesAndTheirTransitiveDependencies3() throws {
+        let sorted = try Algorithms.topologicalSort(validGraph, nodes: Set(["Carthage"])).get()
 		
 		expect(sorted) == [
 			"Argo",
@@ -78,8 +78,8 @@ class AlgorithmTests: XCTestCase {
 		]
 	}
 	
-	func testShouldPerformATopologicalSortOnTheProvidedGraphWhenTheSetIsEmpty() {
-		let sorted = Algorithms.topologicalSort(validGraph, nodes: nil)
+	func testShouldPerformATopologicalSortOnTheProvidedGraphWhenTheSetIsEmpty() throws {
+        let sorted = try Algorithms.topologicalSort(validGraph, nodes: nil).get()
 		
 		expect(sorted) == [
 			"Argo",
@@ -92,28 +92,70 @@ class AlgorithmTests: XCTestCase {
 		]
 	}
 	
-	func testShouldFailWhenThereIsACycleInTheInputGraph1() {
+	func testShouldFailWhenThereIsACycleInTheInputGraph1() throws {
 		let sorted = Algorithms.topologicalSort(cycleGraph)
-		
-		expect(sorted).to(beNil())
+
+        switch sorted {
+        case let .failure(error):
+            switch error {
+            case let .cycle(nodes):
+                XCTAssertEqual(nodes.count, 4)
+                XCTAssertEqual(nodes.first, nodes.last)
+            default:
+                fail("Unexpected error: \(error)")
+            }
+        default:
+            fail("Expected an error to occur")
+        }
 	}
 	
 	func testShouldFailWhenThereIsACycleInTheInputGraph2() {
 		let sorted = Algorithms.topologicalSort(cycleGraph, nodes: Set(["B"]))
 		
-		expect(sorted).to(beNil())
+		switch sorted {
+        case let .failure(error):
+            switch error {
+            case let .cycle(nodes):
+                XCTAssertEqual(nodes.count, 4)
+                XCTAssertEqual(nodes.first, nodes.last)
+            default:
+                fail("Unexpected error: \(error)")
+            }
+        default:
+            fail("Expected an error to occur")
+        }
 	}
 
 
 	func testShouldFailWhenTheInputGraphIsMissingNodes1() {
 		let sorted = Algorithms.topologicalSort(malformedGraph)
 		
-		expect(sorted).to(beNil())
+		switch sorted {
+        case let .failure(error):
+            switch error {
+            case let .missing(node):
+                XCTAssertEqual(node, "B")
+            default:
+                fail("Unexpected error: \(error)")
+            }
+        default:
+            fail("Expected an error to occur")
+        }
 	}
 
 	func testShouldFailWhenTheInputGraphIsMissingNodes2() {
 		let sorted = Algorithms.topologicalSort(malformedGraph, nodes: Set(["A"]))
 		
-		expect(sorted).to(beNil())
+		switch sorted {
+        case let .failure(error):
+            switch error {
+            case let .missing(node):
+                XCTAssertEqual(node, "B")
+            default:
+                fail("Unexpected error: \(error)")
+            }
+        default:
+            fail("Expected an error to occur")
+        }
 	}
 }

--- a/Tests/CarthageKitTests/ProjectTests.swift
+++ b/Tests/CarthageKitTests/ProjectTests.swift
@@ -99,7 +99,7 @@ class ProjectBuildTests: XCTestCase {
 
     func testShouldFallBackToRepoCacheIfCheckoutIsMissing() {
         let macOSexpected = ["TestFramework3_Mac", "TestFramework2_Mac"]
-        let repoDir = directoryURL.appendingPathComponent(carthageProjectCheckoutsPath)
+        let repoDir = directoryURL.appendingPathComponent(Constants.checkoutsPath)
         let checkout = repoDir.appendingPathComponent("TestFramework1")
         let tmpCheckout = repoDir.appendingPathComponent("TestFramework1_BACKUP")
         do {
@@ -730,7 +730,7 @@ class ProjectMiscTests: XCTestCase {
             return
         }
 
-        let result = project.dependencyRetriever.transitiveDependencies(["Moya"], resolvedCartfile: resolvedCartfileValue).single()
+        let result = project.dependencyRetriever.transitiveDependencies(resolvedCartfile: resolvedCartfileValue, includedDependencyNames: ["Moya"]).single()
 
         expect(result?.value).to(contain("Alamofire"))
         expect(result?.value).to(contain("ReactiveSwift"))

--- a/Tests/CarthageKitTests/ResolverTests.swift
+++ b/Tests/CarthageKitTests/ResolverTests.swift
@@ -482,7 +482,7 @@ class ResolverTests: XCTestCase {
         let repository = LocalDependencyStore(directoryURL: repositoryURL)
         
         do {
-            let cartfile = try Cartfile.from(file: testCartfileURL).get()
+            let cartfile = try Cartfile.from(fileURL: testCartfileURL).get()
 
             guard let resolvedCartfile1 = try project.resolveUpdatedDependencies(from: repository,
                                                                                  resolverType: resolverType.self,

--- a/Tests/CarthageKitTests/ResolverTests.swift
+++ b/Tests/CarthageKitTests/ResolverTests.swift
@@ -858,8 +858,9 @@ class ResolverTests: XCTestCase {
 		expect(resolved.error).notTo(beNil())
 		if let error = resolved.error {
 			switch error {
-			case .dependencyCycle:
-				print("Dependency cycle error: \(error)")
+			case let .dependencyCycle(nodes):
+                XCTAssertEqual(nodes.count, 4)
+                XCTAssertEqual(nodes.last, nodes.first)
 			default:
 				fail("Expected error to be of type .dependencyCycle")
 			}

--- a/Tests/CarthageKitTests/ResolverTests.swift
+++ b/Tests/CarthageKitTests/ResolverTests.swift
@@ -880,3 +880,17 @@ extension Project {
         return updatedResolvedCartfile(dependenciesToUpdate, resolver: resolver)
     }
 }
+
+extension ResolvedCartfile {
+    private func dependency(for name: String) -> Dependency? {
+        return dependencies.keys.first(where: { $0.name == name })
+    }
+    
+    fileprivate func version(for name: String) -> PinnedVersion? {
+        if let dependency = dependency(for: name) {
+            return dependencies[dependency]
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/CarthageKitTests/VersionFileTests.swift
+++ b/Tests/CarthageKitTests/VersionFileTests.swift
@@ -224,4 +224,35 @@ class VersionFileTests: XCTestCase {
 			commitish: "v1.0", hashes: ["TestHASH"], swiftVersionMatches: [true]
 		)
 	}
+
+    func testPlatforms() throws {
+
+        let versionFileJSON =
+        """
+        {
+          "sourceHash" : "5318923f7d6f5f3241201bfe0c08701736ee61537a85dbeb8c5ed54fe1c79b10",
+          "configuration" : "Debug",
+          "watchOS" : [
+
+          ],
+          "commitish" : "5.9.2",
+          "iOS" : [
+            {
+              "name" : "INGStyleKit",
+              "hash" : "cc4910feafc10b4ad7f989f0f655966db9295e841cc1a198755e6ff858f2bde4",
+              "swiftToolchainVersion" : "5.0+fa58fb777c65bdcab8df8c9b682c929f"
+            }
+          ]
+        }
+        """
+
+        let versionFile = try VersionFile(jsonData: versionFileJSON.data(using: .utf8)!)
+
+        validate(file: versionFile,
+                 matches: true,
+                 platform: .iOS,
+                 commitish: "5.9.2",
+                 hashes: ["cc4910feafc10b4ad7f989f0f655966db9295e841cc1a198755e6ff858f2bde4"],
+                 swiftVersionMatches: [true])
+    }
 }

--- a/Tests/CarthageKitTests/XcodeTests.swift
+++ b/Tests/CarthageKitTests/XcodeTests.swift
@@ -49,7 +49,7 @@ class XcodeTests: XCTestCase {
 	func testShouldNotFindAnythingInTheCarthageSubdirectory() {
 		let relativePaths = relativePathsForProjectsInDirectory(directoryURL)
 		expect(relativePaths).toNot(beEmpty())
-		let pathsStartingWithCarthage = relativePaths.filter { $0.hasPrefix("\(carthageProjectCheckoutsPath)/") }
+		let pathsStartingWithCarthage = relativePaths.filter { $0.hasPrefix("\(Constants.checkoutsPath)/") }
 		expect(pathsStartingWithCarthage).to(beEmpty())
 	}
 	


### PR DESCRIPTION
- fixed bug in carthage validate where validation would fail if current checkout was not consistent with Cartfile.resolved
- fixes issues with sourceHash being invalidated if auto-generation of schemes is on.
- improved output for dependency cycle error: now the actual cycle is printed.