### PR TITLE
Set destination timeout to 10 seconds

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -849,8 +849,8 @@ public final class Xcode {
                     argsForBuilding.destination = destination
                     // Also set the destination lookup timeout. Since we're building
                     // for the simulator the lookup shouldn't take more than a
-                    // fraction of a second, but we set to 3 just to be safe.
-                    argsForBuilding.destinationTimeout = 3
+                    // fraction of a second, but we set to 10 just to be safe.
+                    argsForBuilding.destinationTimeout = 10
                 }
 
                 // Use `archive` action when building device SDKs to disable LLVM Instrumentation.


### PR DESCRIPTION
We experienced a weird behaviour with carthage that results in not finding the correct simulator during carthage build. Apparently Xcode needs in certain circumstances more than 3 seconds to list all simulators so I increased the timeout to 10 seconds.