### PR TITLE
Recover from a symbol mapper error

### DIFF
--- a/Source/CarthageKit/ProjectDependencyRetriever.swift
+++ b/Source/CarthageKit/ProjectDependencyRetriever.swift
@@ -848,6 +848,7 @@ public final class ProjectDependencyRetriever: DependencyRetrieverProtocol {
                                 if dependencySourceURL.isExistingDirectory {
                                     return DebugSymbolsMapper.mapSymbolLocations(frameworkURL: frameworkSourceURL, dsymURL: dsymURL, sourceURL: dependencySourceURL, urlPrefixMapping: (sourceDirectoryURL, destinationDirectoryURL))
                                         .map { _ in dsymURL }
+                                        .recover(with: .success(dsymURL))
                                 } else {
                                     return .success(dsymURL)
                                 }


### PR DESCRIPTION
I am not sure it is a correct fix for a general case. But it enables ours to build without problem.

## Our case

1. We are using prebuilt-framework of carthage (`carthage archive`) to boost dependency.
2. We created the .zip file and put it to a private GitHub repo.
3. But we do not want to put the source there. All what we want to do is downloading the prebuilt binaries.
4. The binary-only framework does not work for us, since we do not find a private place to store it. So we choose the carthage prebuilt-framework without source files.

## What happens

When doing a `carthage bootstrap`, it skips binary installing:

> Skipped installing OurFramework.framework binary: No matching binary found

After some investigation, the problem is that when copying dSYM to the destination folder, there is a `DebugSymbolsMapper` phase if the `dependencySourceURL` is there.

The `dependencySourceURL` is actually existing since we are hosting a repo on GitHub and it is checked out. However, there is no source code in that folder, the symbol mapper fails and throws an error.

## Fix

Maybe it makes sense to treat the mapper as an optional step and recover the error to a happy path. We can also add some warnings to let users know a potential issue happens. But failing the whole process only due to the mapper failure is too strict for our case.

Maybe there is another way to check whether it is a binary-only project, like checking if there is a scheme in the `dependencySourceURL` to build. But I am not sure how.
