### PR TITLE
Fix checkout of dependency with a binary dependency

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -269,8 +269,13 @@ public final class Project { // swiftlint:disable:this type_body_length
                             }
                         }
                         .flatMap(.concat) { dependency, version -> SignalProducer<(), CarthageError> in
-                           // symlink the checkout paths for every dependency
-                           return self.symlinkCheckoutPaths(for: dependency, version: version, resolvedCartfile: cartfile)
+                            switch dependency {
+                            case .git, .gitHub:
+                                // symlink the checkout paths for checked-out dependencies
+                                return self.symlinkCheckoutPaths(for: dependency, version: version, resolvedCartfile: cartfile)
+                            case .binary:
+                                return .empty
+                            }
                         }
             })
             .then(self.removeNonExistingDependencyDirectories())


### PR DESCRIPTION
In case a dependency has itself a binary dependency, carthage had a silent deadlock, because it tried to symlink the checkout directory of the binary dependency, which doesn't exist.

This PR fixes the deadlock by propagating the `.launchFailed` error and leaving the `DispatchGroup` as it is also done for the process termination in an error case. After fixing this, I could see the error message and pinpoint the other bug to trying to symlink the checkout paths of binary dependencies.

I wanted to add a test for this, but I would need some support with this. @werner77 do you think this would be a unit test or rather an integration test? I cannot find any other unit tests that try to checkout some dependencies and assert something afterwards, but we might be able to create a test that is similar to `relink-conflicting-not-checked-in-symlink.bats`. 

To test the issue before this PR and this fix, it is sufficient to use this Cartfile:

```
github "tealium/tealium-swift" == 1.9.4
```

and run the following command

```
carthage update tealium-swift --platform ios
```