### PR TITLE
Add support for tar binaries in BinaryProjectCache

### DIFF
--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -104,13 +104,16 @@ public final class Archive {
 
     // MARK: - Internal
 
+    static func hasTarExtension(fileURL: URL) -> Bool {
+        return ["gz", "tgz", "bz2", "xz"].contains(fileURL.pathExtension)
+    }
+
     /// Unarchives the given file URL into a temporary directory, using its
     /// extension to detect archive type, then sends the file URL to that directory.
     static func unarchive(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
-        switch fileURL.pathExtension {
-        case "gz", "tgz", "bz2", "xz":
+        if hasTarExtension(fileURL: fileURL) {
             return untar(archive: fileURL)
-        default:
+        } else {
             return unzip(archive: fileURL)
         }
     }

--- a/Source/CarthageKit/BinariesCache.swift
+++ b/Source/CarthageKit/BinariesCache.swift
@@ -153,20 +153,30 @@ final class BinaryProjectCache: AbstractBinariesCache {
                 let response = result.1
                 if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
                     return SignalProducer(error: CarthageError.httpError(statusCode: httpResponse.statusCode))
-                } else if Archive.hasTarExtension(fileURL: sourceURL) {
-                    let tempURL = destinationURL.deletingLastPathComponent().appendingPathComponent(sourceURL.lastPathComponent)
-                    return Files.moveFile(from: downloadURL, to: tempURL)
-                        .flatMap(.concat) { url -> SignalProducer<URL, CarthageError> in
-                            return Archive.unarchive(archive: url)
-                        }
-                        .flatMap(.concat) { archiveURL -> SignalProducer<URL, CarthageError> in
-                            return Archive.zip(paths: [archiveURL.path], into: destinationURL, workingDirectoryURL: archiveURL.deletingLastPathComponent())
-                        }
                 } else {
-                    return Files.moveFile(from: downloadURL, to: destinationURL)
+                    return self.rezipIfNeeded(sourceURL: sourceURL, downloadURL: downloadURL)
+                        .flatMap(.concat) { archiveURL -> SignalProducer<URL, CarthageError> in
+                            return Files.moveFile(from: archiveURL, to: destinationURL)
+                        }
                 }
             }
             .then(SignalProducer<(), CarthageError>.empty)
+    }
+
+    private func rezipIfNeeded(sourceURL: URL, downloadURL: URL) -> SignalProducer<URL, CarthageError> {
+        guard Archive.hasTarExtension(fileURL: sourceURL) else {
+            return SignalProducer<URL, CarthageError>(value: downloadURL)
+        }
+
+        // Untar and zip again
+        let tempURL = downloadURL.deletingLastPathComponent().appendingPathComponent(sourceURL.lastPathComponent)
+        return Files.moveFile(from: downloadURL, to: tempURL)
+            .flatMap(.concat) { Archive.unarchive(archive: $0) }
+            .flatMap(.concat) { directoryURL -> SignalProducer<URL, CarthageError> in
+                let zipArchiveFileName = "archive.zip"
+                let zipArchiveURL = directoryURL.appendingPathComponent(zipArchiveFileName)
+                return Archive.zip(paths: ["."], into: zipArchiveURL, workingDirectoryURL: directoryURL)
+            }
     }
 }
 


### PR DESCRIPTION
Currently, the `BinaryProjectCache` only supports zipped binaries, because the [`func fileURL`](https://github.com/nsoperations/Carthage/blob/master/Source/CarthageKit/BinariesCache.swift#L17-L28) always uses `.zip` as extension. This leads to errors while trying to install the binary, because the downloaded `.tar.gz` will be saved as `.zip`, which will cause the `unarchive` method to choose the wrong command:

<details>

<summary>Error message</summary>

```
*** Installing GoogleSymbolUtilities binary at "1.1.2"

error: A shell task (/usr/bin/env unzip -uo -qq -d /var/folders/m2/8kggf73s7tdc3c14z5btfx5w0000gn/T/carthage.7IKXnv /Users/ffittschen/Library/Caches/org.carthage.CarthageKit/binaries/5.2.4+4a9cf962c5cb38b44e1c5e4e5349a4e3/GoogleSymbolUtilities/1.1.2/Release/GoogleSymbolUtilities.framework.zip) failed with exit code 9:
[/Users/ffittschen/Library/Caches/org.carthage.CarthageKit/binaries/5.2.4+4a9cf962c5cb38b44e1c5e4e5349a4e3/GoogleSymbolUtilities/1.1.2/Release/GoogleSymbolUtilities.framework.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /Users/ffittschen/Library/Caches/org.carthage.CarthageKit/binaries/5.2.4+4a9cf962c5cb38b44e1c5e4e5349a4e3/GoogleSymbolUtilities/1.1.2/Release/GoogleSymbolUtilities.framework.zip or
        /Users/ffittschen/Library/Caches/org.carthage.CarthageKit/binaries/5.2.4+4a9cf962c5cb38b44e1c5e4e5349a4e3/GoogleSymbolUtilities/1.1.2/Release/GoogleSymbolUtilities.framework.zip.zip, and cannot find /Users/ffittschen/Library/Caches/org.carthage.CarthageKit/binaries/5.2.4+4a9cf962c5cb38b44e1c5e4e5349a4e3/GoogleSymbolUtilities/1.1.2/Release/GoogleSymbolUtilities.framework.zip.ZIP, period.
```

</details>

To add support for binaries that use a tar format, we have two possibilities:
1. Adapt the `fileURL` method to use the extension of its binaryURL in case of a binary dependency
2. Unarchive the downloaded binary and zip it again if it uses the tar format.

Although the first solution would be "cleaner", I wasn't sure about the implications, so this PR is a proposal to solve this issue by implementing the second possibility. If the first option doesn't have any implications, I'm happy to change the PR to that option.

To reproduce the issue that will be solved by this PR, one can use the following files:

<details open>
<summary>GoogleSymbolUtilities.json</summary>

```
{
  "1.1.2":"https://dl.google.com/dl/cpdc/7ecdffda6fbef4af/GoogleSymbolUtilities-1.1.2.tar.gz"
}
```

</details>

<details open>

<summary>Cartfile</summary>

```
binary "GoogleSymbolUtilities.json"
```

</details>
